### PR TITLE
fix: update TypeSpec syntax for @service and @info decorators

### DIFF
--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -20,10 +20,10 @@ import "./routes/upload.tsp";
 using Http;
 using OpenAPI;
 
-@service({
+@service(#{
   title: "Admin API",
 })
-@info({
+@info(#{
   version: "1.0.0",
 })
 namespace AdminAPI;


### PR DESCRIPTION
## Summary
- Update TypeSpec syntax to use #{} for object literals in @service and @info decorators
- Fixes compilation errors with TypeSpec v0.67.2

## Test plan
- Run `task tsp` and verify it compiles without errors
- Verify OpenAPI spec is generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)