### PR TITLE
docs: add server running and debugging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ task docker-build
 task docker-run
 ```
 
+### Running the Server
+
+```bash
+# Run the main server (includes both public and admin)
+go run main.go
+
+# The server starts on http://localhost:8181/
+# - Public blog: http://localhost:8181/
+# - Admin panel: http://localhost:8181/admin
+
+# Debug with Delve
+dlv debug main.go
+
+# Build and run
+go build -o blog4
+./blog4
+```
+
 ### Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Add clear instructions for running the server with `go run main.go`
- Include server URLs for both public blog and admin panel
- Add debugging options with Delve
- Clarify that the main server includes both public and admin routes

## Test plan
- [x] Documentation only change, no code changes
- [x] Verified commands work correctly
- [x] URLs are accurate (localhost:8181)

🤖 Generated with [Claude Code](https://claude.ai/code)