### PR TITLE
refactor: migrate from log.Printf to slog and improve error handling

### DIFF
--- a/server/admin/entry_image_worker.go
+++ b/server/admin/entry_image_worker.go
@@ -2,9 +2,10 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"github.com/tokuhirom/blog4/db/admin/admindb"
 	"github.com/tokuhirom/blog4/server"
-	"log"
+	"log/slog"
 )
 
 type EntryImageWorker struct {
@@ -20,11 +21,11 @@ func NewEntryImageWorker(queries *admindb.Queries) *EntryImageWorker {
 func (w *EntryImageWorker) processEntryImages(ctx context.Context) error {
 	entries, err := w.service.GetEntryImageNotProcessedEntries(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get unprocessed entries for image generation: %w", err)
 	}
 	for _, entry := range entries {
 		if err := w.service.ProcessEntry(ctx, entry); err != nil {
-			log.Printf("Failed to process entry: %v", err)
+			slog.Error("Failed to process entry image", slog.String("path", entry.Path), slog.Any("error", err))
 		}
 	}
 	return nil

--- a/server/keep_alive.go
+++ b/server/keep_alive.go
@@ -1,23 +1,23 @@
 package server
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 )
 
 // KeepAlive apprun が今 min-scale 0 なので､寝ないように自分で自分を起こし続ける
 func KeepAlive(url string) {
-	log.Printf("Starting keep-alive process for %s...", url)
+	slog.Info("Starting keep-alive process", slog.String("url", url))
 	for {
 		time.Sleep(10 * time.Second)
 		resp, err := http.Get(url)
 		if err != nil {
-			log.Printf("failed to request %s: %v", url, err)
+			slog.Error("failed to request keep-alive URL", slog.String("url", url), slog.Any("error", err))
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			log.Printf("unexpected status code: %d", resp.StatusCode)
+			slog.Warn("unexpected keep-alive status code", slog.Int("status", resp.StatusCode), slog.String("url", url))
 		}
 		_ = resp.Body.Close()
 	}

--- a/server/middleware/web_accel_guard.go
+++ b/server/middleware/web_accel_guard.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 )
 
@@ -10,7 +10,7 @@ func CheckWebAccelHeader(token string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotToken := r.Header.Get("X-WebAccel-Guard")
 			if gotToken != token && r.URL.Path != "/healthz" {
-				log.Printf("invalid X-WebAccel-Guard header: '%s'", gotToken)
+				slog.Warn("invalid X-WebAccel-Guard header", slog.String("got_token", gotToken), slog.String("path", r.URL.Path))
 				http.Error(w, "Invalid X-WebAccel-Guard header", http.StatusBadRequest)
 				return
 			}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tokuhirom/blog4/server/admin"
 	middleware2 "github.com/tokuhirom/blog4/server/middleware"
 	"github.com/tokuhirom/blog4/server/sobs"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 )
@@ -20,7 +20,7 @@ func BuildRouter(cfg server.Config, sqlDB *sql.DB, sobsClient *sobs.SobsClient) 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	if cfg.WebAccelGuard != "" {
-		log.Printf("CheckWebAccelHeader validation enabled")
+		slog.Info("CheckWebAccelHeader validation enabled")
 		r.Use(middleware2.CheckWebAccelHeader(cfg.WebAccelGuard))
 	}
 
@@ -35,7 +35,7 @@ func HealthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte("ok"))
 	if err != nil {
-		log.Printf("failed to write response: %v", err)
+		slog.Error("failed to write healthz response", slog.Any("error", err))
 	}
 }
 
@@ -48,6 +48,6 @@ func GitHashHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(gitHash))
 	if err != nil {
-		log.Printf("failed to write response: %v", err)
+		slog.Error("failed to write git hash response", slog.Any("error", err))
 	}
 }


### PR DESCRIPTION
## Summary
- Migrate all logging from `log.Printf` to structured logging with `slog`
- Improve error handling with descriptive `fmt.Errorf` messages
- Use structured logging attributes (slog.String, slog.Int, slog.Any)
- Add context to errors (file paths, ASINs, bucket names, etc.)

## Changes by Package
- **main.go**: Migrate startup logging to slog
- **server/**: Migrate keep-alive, backup, and router logging
- **server/admin/**: Migrate admin routes, Amazon integration, and entry image processing
- **server/sobs/**: Add error context to S3 operations
- **server/middleware/**: Migrate web accel guard logging

## Test plan
- [x] Code compiles successfully (`go build .`)
- [x] All error paths now include descriptive context
- [x] Structured logging provides better observability

🤖 Generated with [Claude Code](https://claude.ai/code)