### PR TITLE
refactor: complete slog migration for remaining files

### DIFF
--- a/markdown/asin.go
+++ b/markdown/asin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/tokuhirom/blog4/db/public/publicdb"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -122,7 +123,7 @@ func (r *AsinRenderer) Render(writer util.BufWriter, source []byte, node ast.Nod
 func (r *AsinRenderer) enter(w util.BufWriter, n *AsinNode, src []byte) (ast.WalkStatus, error) {
 	asin, err := r.Queries.GetAsin(r.Context, string(n.Target))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get ASIN %s: %w", n.Target, err)
 	}
 	w.WriteString("<div style='display: flex;' class='asin'>")
 	w.WriteString("<p>")

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -3,12 +3,14 @@ package markdown
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"html/template"
+
 	"github.com/tokuhirom/blog4/db/public/publicdb"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
-	"html/template"
 )
 
 type Markdown struct {
@@ -50,7 +52,7 @@ func NewMarkdown(ctx context.Context, queries *publicdb.Queries) *Markdown {
 func (m *Markdown) Render(input string) (template.HTML, error) {
 	var buf bytes.Buffer
 	if err := m.md.Convert([]byte(input), &buf); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to convert markdown: %w", err)
 	}
 	return template.HTML(buf.String()), nil
 }

--- a/markdown/wiki_link.go
+++ b/markdown/wiki_link.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/tokuhirom/blog4/db/public/publicdb"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -115,7 +116,7 @@ func (r *WikiRenderer) Render(writer util.BufWriter, source []byte, node ast.Nod
 	if entering {
 		_, err := writer.WriteString(string(n.Target))
 		if err != nil {
-			return ast.WalkStop, err
+			return ast.WalkStop, fmt.Errorf("failed to write target: %w", err)
 		}
 		return ast.WalkSkipChildren, nil
 	}

--- a/server/admin/pubsubhubbub.go
+++ b/server/admin/pubsubhubbub.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -25,8 +25,8 @@ func NotifyHub(hubURL string, feedURL string) error {
 		strings.NewReader(formData.Encode()),
 	)
 	if err != nil {
-		log.Printf("Failed to notify Hub: %v\n", err)
-		return err
+		slog.Error("Failed to notify Hub", slog.String("hub_url", hubURL), slog.String("feed_url", feedURL), slog.Any("error", err))
+		return fmt.Errorf("failed to post to hub %s: %w", hubURL, err)
 	}
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
@@ -35,10 +35,10 @@ func NotifyHub(hubURL string, feedURL string) error {
 	// Check response status
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		err := fmt.Errorf("hub notification failed: %d %s", resp.StatusCode, resp.Status)
-		log.Printf("Failed to notify Hub: %v\n", err)
+		slog.Error("Failed to notify Hub", slog.String("hub_url", hubURL), slog.Int("status_code", resp.StatusCode), slog.String("status", resp.Status))
 		return err
 	}
 
-	log.Printf("Notification sent to Hub: %s\n", hubURL)
+	slog.Info("Notification sent to Hub", slog.String("hub_url", hubURL), slog.String("feed_url", feedURL))
 	return nil
 }

--- a/server/admin/twohop.go
+++ b/server/admin/twohop.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/tokuhirom/blog4/db/admin/admindb"
-	"github.com/tokuhirom/blog4/server/admin/openapi"
 	"log/slog"
 	"strings"
+
+	"github.com/tokuhirom/blog4/db/admin/admindb"
+	"github.com/tokuhirom/blog4/server/admin/openapi"
 )
 
 func getLinkPalletData(ctx context.Context, db *sql.DB, queries *admindb.Queries, targetPath string, targetTitle string) (*openapi.LinkPalletData, error) {
@@ -20,7 +21,7 @@ func getLinkPalletData(ctx context.Context, db *sql.DB, queries *admindb.Queries
 	// このエントリにリンクしているページのリストを取得
 	reverseLinks, err := queries.GetEntriesByLinkedTitle(ctx, targetTitle)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get entries by linked title %s: %w", targetTitle, err)
 	}
 
 	// links の指す先のタイトルにリンクしているエントリのリストを取得

--- a/server/admin/twohop.go
+++ b/server/admin/twohop.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/tokuhirom/blog4/db/admin/admindb"
 	"github.com/tokuhirom/blog4/server/admin/openapi"
-	"log"
+	"log/slog"
 	"strings"
 )
 
@@ -14,7 +14,7 @@ func getLinkPalletData(ctx context.Context, db *sql.DB, queries *admindb.Queries
 	// このエントリがリンクしているページのリストを取得
 	links, err := queries.GetLinkedEntries(ctx, targetPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get linked entries for path %s: %w", targetPath, err)
 	}
 
 	// このエントリにリンクしているページのリストを取得
@@ -91,7 +91,7 @@ func getEntriesByLinkedTitles(ctx context.Context, db *sql.DB, targetPath string
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
 		if err != nil {
-			log.Printf("Cannot close: %v", err)
+			slog.Error("Cannot close rows", slog.Any("error", err))
 		}
 	}(rows)
 


### PR DESCRIPTION
## Summary
- Complete the migration from `log.Printf` to structured logging with `slog`
- All remaining files have been updated to use slog
- Added descriptive error context with `fmt.Errorf`

## Files Updated
- **server/public.go**: Migrated all log.Printf calls in the public server
- **server/admin/pubsubhubbub.go**: Updated PubSubHubbub notification logging
- **server/admin/twohop.go**: Fixed rows close error logging
- **server/admin/service/entry_image.go**: Updated image processing debug logs

## Benefits
- Consistent structured logging throughout the codebase
- Better error context for debugging
- Machine-readable log format for production environments
- No more unstructured log.Printf calls

## Test plan
- [x] Code compiles successfully (`go build .`)
- [x] Verified no remaining log.Printf calls with `ag "log\.Printf" --go`
- [x] All error messages include descriptive context

🤖 Generated with [Claude Code](https://claude.ai/code)