### PR TITLE
refactor: remove os.Exit from library code

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	sobsClient := sobs.NewSobsClient(cfg.S3AccessKeyId, cfg.S3SecretAccessKey, cfg.S3Region, cfg.S3AttachmentsBucketName, cfg.S3BackupBucketName, cfg.S3Endpoint)
+	sobsClient, err := sobs.NewSobsClient(cfg.S3AccessKeyId, cfg.S3SecretAccessKey, cfg.S3Region, cfg.S3AttachmentsBucketName, cfg.S3BackupBucketName, cfg.S3Endpoint)
+	if err != nil {
+		slog.Error("failed to create S3 client", slog.Any("error", err))
+		os.Exit(1)
+	}
 
 	r := router.BuildRouter(cfg, sqlDB, sobsClient)
 

--- a/server/public.go
+++ b/server/public.go
@@ -237,8 +237,8 @@ func getRelatedEntries(context context.Context, queries *publicdb.Queries, entry
 	for _, entry := range uniqueEntriesMap {
 		if entry.Visibility != "public" {
 			// 保険的にvisibilityがpublicでないエントリは除外
-			slog.Error("visibility is not public", slog.String("path", entry.Path), slog.String("visibility", string(entry.Visibility)))
-			os.Exit(1)
+			slog.Error("unexpected non-public entry in related entries", slog.String("path", entry.Path), slog.String("visibility", string(entry.Visibility)))
+			continue // Skip this entry instead of exiting
 		}
 		uniqueEntries = append(uniqueEntries, entry)
 	}


### PR DESCRIPTION
## Summary
- Remove inappropriate use of `os.Exit` from library functions
- Library code should return errors, not terminate the program
- Let callers decide how to handle errors

## Changes
1. **server/sobs/s3_client.go**:
   - Changed `NewSobsClient` to return `(*SobsClient, error)`
   - Return error instead of calling `os.Exit` when credentials are missing
   - Return error instead of calling `os.Exit` when minio client initialization fails
   - Removed unused `os` import

2. **main.go**:
   - Updated to handle error from `NewSobsClient`
   - Exit with error message if S3 client creation fails

3. **server/public.go**:
   - Changed `os.Exit(1)` to `continue` when encountering non-public entries
   - Log error but skip the entry instead of terminating the program

## Benefits
- Better error handling architecture
- Allows for graceful error recovery
- Makes the code more testable
- Follows Go best practices

## Test plan
- [x] Code compiles successfully
- [x] Error handling paths are properly implemented
- [x] No more os.Exit calls in library code

🤖 Generated with [Claude Code](https://claude.ai/code)