### PR TITLE
chore: remove binary from git and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ deploy.json
 app.jsonnet
 app.json
 node_modules/
+
+# Binary
+/blog4


### PR DESCRIPTION
## Summary
- Remove the `blog4` binary file from git tracking
- Add `/blog4` to `.gitignore` to prevent future accidental commits

## Why?
- Binary files should not be committed to version control
- They can be large and change frequently
- They should be built locally or in CI/CD

## Changes
1. Removed `blog4` binary from git
2. Added `/blog4` to `.gitignore`

## Test plan
- [x] Binary removed from git
- [x] `.gitignore` updated
- [x] Future builds won't accidentally commit the binary

🤖 Generated with [Claude Code](https://claude.ai/code)