### PR TITLE
fix: handle missing ASINs gracefully in markdown rendering

### DIFF
--- a/markdown/asin.go
+++ b/markdown/asin.go
@@ -3,7 +3,10 @@ package markdown
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/tokuhirom/blog4/db/public/publicdb"
 	"github.com/yuin/goldmark"
@@ -123,7 +126,16 @@ func (r *AsinRenderer) Render(writer util.BufWriter, source []byte, node ast.Nod
 func (r *AsinRenderer) enter(w util.BufWriter, n *AsinNode, src []byte) (ast.WalkStatus, error) {
 	asin, err := r.Queries.GetAsin(r.Context, string(n.Target))
 	if err != nil {
-		return 0, fmt.Errorf("failed to get ASIN %s: %w", n.Target, err)
+		// If ASIN not found, render a placeholder or the raw ASIN link
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("ASIN not found in database, rendering as plain text", slog.String("asin", string(n.Target)))
+		} else {
+			slog.Error("Failed to query ASIN", slog.String("asin", string(n.Target)), slog.Any("error", err))
+		}
+		w.WriteString("[asin:")
+		w.Write(n.Target)
+		w.WriteString(":detail]")
+		return ast.WalkSkipChildren, nil
 	}
 	w.WriteString("<div style='display: flex;' class='asin'>")
 	w.WriteString("<p>")


### PR DESCRIPTION
## Summary
- Fix rendering failure when ASIN is not found in database
- Render the raw ASIN markup instead of throwing error
- Add proper logging to track missing ASINs

## Problem
Previously, when an ASIN was not found in the database, the entire markdown rendering would fail with an error. This could happen when:
- The ASIN hasn't been cached yet
- The Amazon API is temporarily unavailable
- The ASIN is invalid or removed from Amazon

## Solution
- Catch the error when ASIN is not found
- Render the original `[asin:XXXXXX:detail]` text instead
- Add logging to distinguish between:
  - Missing ASIN (warning level) - expected case
  - Query errors (error level) - unexpected database issues

## Test plan
- [x] Code compiles successfully
- [x] Missing ASINs no longer break rendering
- [x] Original ASIN markup is preserved when data unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)