### PR TITLE
refactor: move main.go to cmd/blog4 directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ task --watch gen  # Watch mode for code generation
 
 # Build
 task frontend-build  # Build frontend assets
-go build .          # Build Go binary
+go build ./cmd/blog4  # Build Go binary
 
 # Docker
 task docker-build   # Build Docker image
@@ -61,7 +61,7 @@ task docker-run     # Run Docker container
 
 ### Code Generation Pipeline
 1. **TypeSpec** (`/typespec/*.tsp`) → OpenAPI spec
-2. **OpenAPI** → Go server code via Ogen (`go generate main.go`)
+2. **OpenAPI** → Go server code via Ogen (`go generate ./cmd/blog4/main.go`)
 3. **OpenAPI** → TypeScript client via Orval (no Java required)
 4. **SQL** (`/db/*/queries/*.sql`) → Go code via SQLC
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
-RUN go build -o /app/server .
+RUN go build -o /app/server ./cmd/blog4
 
 # Stage 3: Final stage
 FROM ubuntu:24.04

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ task frontend
 
 # Build production assets
 task frontend-build
-go build .
+go build ./cmd/blog4
 
 # Docker operations
 task docker-build
@@ -52,17 +52,17 @@ task docker-run
 
 ```bash
 # Run the main server (includes both public and admin)
-go run main.go
+go run ./cmd/blog4
 
 # The server starts on http://localhost:8181/
 # - Public blog: http://localhost:8181/
 # - Admin panel: http://localhost:8181/admin
 
 # Debug with Delve
-dlv debug main.go
+dlv debug ./cmd/blog4
 
 # Build and run
-go build -o blog4
+go build -o blog4 ./cmd/blog4
 ./blog4
 ```
 
@@ -70,6 +70,8 @@ go build -o blog4
 
 ```
 blog4/
+├── cmd/
+│   └── blog4/       # Main application entry point
 ├── db/               # Database schemas and queries
 │   ├── admin/       # Admin database (write operations)
 │   └── public/      # Public database (read operations)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,10 +75,10 @@ tasks:
   ogen:
     deps: ['tsp']
     cmds:
-      - go generate main.go
+      - go generate ./cmd/blog4/main.go
     sources:
       - typespec/tsp-output/@typespec/openapi3/openapi.yaml
-      - main.go
+      - ./cmd/blog4/main.go
     generates:
       - ./server/admin/openapi/oas_cfg_gen.go
       - ./server/admin/openapi/oas_client_gen.go

--- a/cmd/blog4/main.go
+++ b/cmd/blog4/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen@latest --target ./server/admin/openapi -package openapi --clean typespec/tsp-output/@typespec/openapi3/openapi.yaml
+//go:generate go run github.com/ogen-go/ogen/cmd/ogen@latest --target ../../server/admin/openapi -package openapi --clean ../../typespec/tsp-output/@typespec/openapi3/openapi.yaml
 
 func main() {
 	if err := DoMain(); err != nil {


### PR DESCRIPTION
## Summary
- Reorganized project structure by moving main.go to cmd/blog4 directory
- Follows Go standard project layout for command-line applications
- Updated all references to main.go across the codebase

## Changes
- **cmd/blog4/main.go**: Moved from root directory with updated go:generate paths
- **Dockerfile**: Updated build command to use cmd/blog4
- **Taskfile.yml**: Updated ogen task to reference new main.go location
- **README.md**: Updated all go run/build commands and project structure
- **CLAUDE.md**: Updated build commands and code generation references

## Test plan
- [x] Verified go build ./cmd/blog4 works correctly
- [x] Ran golangci-lint - no issues found
- [x] Checked all documentation references are updated
- [x] Ensured go:generate paths are correct relative to new location

🤖 Generated with [Claude Code](https://claude.ai/code)