### PR TITLE
fix: prevent focus loss in entry editor

### DIFF
--- a/web/admin/src/components/MarkdownEditor.tsx
+++ b/web/admin/src/components/MarkdownEditor.tsx
@@ -133,21 +133,5 @@ export default function MarkdownEditor({
 		};
 	}, [initialContent]);
 
-	// Update editor content when initialContent changes (without recreating the editor)
-	useEffect(() => {
-		if (editorRef.current && initialContent !== undefined) {
-			const currentContent = editorRef.current.state.doc.toString();
-			if (currentContent !== initialContent) {
-				editorRef.current.dispatch({
-					changes: {
-						from: 0,
-						to: currentContent.length,
-						insert: initialContent,
-					},
-				});
-			}
-		}
-	}, [initialContent]);
-
 	return <div ref={containerRef} className={styles.editor} />;
 }

--- a/web/admin/src/pages/AdminEntryPage.tsx
+++ b/web/admin/src/pages/AdminEntryPage.tsx
@@ -323,7 +323,8 @@ export default function AdminEntryPage() {
 							</label>
 							<div className={styles.editor}>
 								<MarkdownEditor
-									initialContent={body}
+									key={path}
+									initialContent={entry.Body}
 									onUpdateText={(text) => {
 										setBody(text);
 										handleInputBody();


### PR DESCRIPTION
## Summary
- Fixed the issue where the editor loses focus after typing each character
- The problem was caused by recreating the MarkdownEditor component on every state change

## Changes
- Changed `initialContent` from `body` state to `entry.Body` to prevent unnecessary re-renders
- Added `key={path}` to force recreate the editor only when switching between entries
- Removed the unnecessary effect that was updating editor content

## Technical Details
The issue occurred because:
1. Every character typed updates the `body` state
2. The `body` state was passed as `initialContent` prop to MarkdownEditor
3. This caused React to recreate the editor component, losing focus

The fix ensures the editor is only recreated when navigating to a different entry (path changes).

## Test plan
- [x] Open an entry in the admin panel
- [x] Type multiple characters continuously
- [x] Verify focus is maintained while typing
- [x] Switch between different entries
- [x] Verify the correct content loads for each entry

🤖 Generated with [Claude Code](https://claude.ai/code)