### PR TITLE
feat: change frontend dev server port to 6173

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -34,9 +34,9 @@ func Router(cfg server.Config, db *sql.DB, sobsClient *sobs.SobsClient) (*chi.Mu
 	r := chi.NewRouter()
 	//r.Use(middleware.BasicAuth("admin", map[string]string{cfg.AdminUser: cfg.AdminPassword}))
 	if cfg.LocalDev {
-		slog.Info("LocalDevelopment mode enabled. CORS is allowed", slog.String("origin", "http://localhost:5173"))
+		slog.Info("LocalDevelopment mode enabled. CORS is allowed", slog.String("origin", "http://localhost:6173"))
 		r.Use(cors.Handler(cors.Options{
-			AllowedOrigins:   []string{"http://localhost:5173"},
+			AllowedOrigins:   []string{"http://localhost:6173"},
 			AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 			AllowCredentials: true,

--- a/web/admin/vite.config.js
+++ b/web/admin/vite.config.js
@@ -5,4 +5,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	base: "/admin/",
 	plugins: [react()],
+	server: {
+		port: 6173,
+	},
 });


### PR DESCRIPTION
## Summary
- Changed Vite dev server port from default 5173 to 6173
- Updated CORS configuration to allow the new port

## Changes
1. **Vite configuration** (`web/admin/vite.config.js`)
   - Added server configuration with port 6173

2. **CORS configuration** (`internal/admin/admin.go`)
   - Updated allowed origins from `http://localhost:5173` to `http://localhost:6173`

## Reason
The default Vite port (5173) conflicts with other projects. Using 6173 avoids this conflict.

## Test plan
- [ ] Run `task frontend` or `npm run dev` in web/admin
- [ ] Verify the dev server starts on port 6173
- [ ] Verify the admin interface works correctly at http://localhost:6173
- [ ] Verify API calls work with the updated CORS configuration

🤖 Generated with [Claude Code](https://claude.ai/code)