### PR TITLE
fix: update golangci-lint to v2.1.6 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1.6
           args: --timeout=5m
 
       - name: Run Go tests


### PR DESCRIPTION
The CI was failing because 'version: latest' was resolving to an old version that couldn't analyze the generated OpenAPI code. Explicitly set to v2.1.6.

🤖 Generated with [Claude Code](https://claude.ai/code)