### PR TITLE
fix: correct path parsing for entry detail pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(goimports:*)",
-      "Bash(mkdir:*)"
+      "Bash(mkdir:*)",
+      "WebFetch(domain:localhost)",
+      "Bash(git restore:*)"
     ],
     "deny": []
   }

--- a/web/admin/src/pages/AdminEntryPage.tsx
+++ b/web/admin/src/pages/AdminEntryPage.tsx
@@ -33,7 +33,9 @@ const api = createAdminApiClient();
 export default function AdminEntryPage() {
 	const location = useLocation();
 	const navigate = useNavigate();
-	const path = location.pathname.replace("/entry/", "");
+	const path = location.pathname
+		.replace("/admin/entry/", "")
+		.replace("/entry/", "");
 
 	const [entry, setEntry] = useState<GetLatestEntriesRow>(
 		{} as GetLatestEntriesRow,


### PR DESCRIPTION
## Summary
- Fix 404 error when accessing entry detail pages in admin interface
- Properly handle the `/admin/entry/` URL prefix in path extraction

## Problem
Entry detail pages were returning 404 errors because the path extraction logic only removed `/entry/` but didn't account for the React Router `basename="/admin"` configuration, resulting in incorrect paths being sent to the API.

## Solution
Updated `AdminEntryPage.tsx` to correctly parse paths from URLs like `/admin/entry/some-path` by removing both `/admin/entry/` and `/entry/` prefixes.

## Test plan
- [x] Code formatted with biome
- [ ] Navigate to http://localhost:6173/admin
- [ ] Login with admin credentials
- [ ] Click on any entry in the list
- [ ] Verify entry detail page loads without 404 error

🤖 Generated with [Claude Code](https://claude.ai/code)