### PR TITLE
chore: remove version from pnpm/action-setup for Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.2
 
       - name: Install dependencies with pnpm
         run: pnpm install
@@ -109,8 +107,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.2
 
       - name: Install TypeSpec dependencies
         run: pnpm install

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.2
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- Removed explicit version specification from pnpm/action-setup in GitHub Actions workflows
- This enables Renovate to automatically manage and update the action version

## Changes
- Updated `.github/workflows/ci.yml` - removed version from pnpm/action-setup
- Updated `.github/workflows/deploy-api-docs.yml` - removed version from pnpm/action-setup

## Benefits
- Renovate can now automatically create PRs for pnpm/action-setup updates
- Consistent with dependency management best practices
- Reduces manual maintenance burden

🤖 Generated with [Claude Code](https://claude.ai/code)