### PR TITLE
refactor: CORS設定をLocalDevから分離

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       # Application configuration
       BLOG_PORT: 8181
       LOCAL_DEV: true
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:6173}
       ADMIN_USER: ${ADMIN_USER:-admin}
       ADMIN_PW: ${ADMIN_PASSWORD:-admin}
       

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -33,10 +33,10 @@ func Router(cfg server.Config, db *sql.DB, sobsClient *sobs.SobsClient) (*chi.Mu
 
 	r := chi.NewRouter()
 	//r.Use(middleware.BasicAuth("admin", map[string]string{cfg.AdminUser: cfg.AdminPassword}))
-	if cfg.LocalDev {
-		slog.Info("LocalDevelopment mode enabled. CORS is allowed", slog.String("origin", "http://localhost:6173"))
+	if len(cfg.AllowedOrigins) > 0 {
+		slog.Info("CORS is allowed", slog.Any("origins", cfg.AllowedOrigins))
 		r.Use(cors.Handler(cors.Options{
-			AllowedOrigins:   []string{"http://localhost:6173"},
+			AllowedOrigins:   cfg.AllowedOrigins,
 			AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 			AllowCredentials: true,

--- a/server/admin/openapi/oas_client_gen.go
+++ b/server/admin/openapi/oas_client_gen.go
@@ -66,7 +66,7 @@ type Invoker interface {
 	GetAllEntryTitles(ctx context.Context) (GetAllEntryTitlesRes, error)
 	// GetBuildInfo invokes getBuildInfo operation.
 	//
-	// GET /api/build-info
+	// GET /build-info
 	GetBuildInfo(ctx context.Context) (GetBuildInfoRes, error)
 	// GetEntryByDynamicPath invokes getEntryByDynamicPath operation.
 	//
@@ -623,7 +623,7 @@ func (c *Client) sendGetAllEntryTitles(ctx context.Context) (res GetAllEntryTitl
 
 // GetBuildInfo invokes getBuildInfo operation.
 //
-// GET /api/build-info
+// GET /build-info
 func (c *Client) GetBuildInfo(ctx context.Context) (GetBuildInfoRes, error) {
 	res, err := c.sendGetBuildInfo(ctx)
 	return res, err
@@ -633,7 +633,7 @@ func (c *Client) sendGetBuildInfo(ctx context.Context) (res GetBuildInfoRes, err
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBuildInfo"),
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.HTTPRouteKey.String("/api/build-info"),
+		semconv.HTTPRouteKey.String("/build-info"),
 	}
 
 	// Run stopwatch.
@@ -666,7 +666,7 @@ func (c *Client) sendGetBuildInfo(ctx context.Context) (res GetBuildInfoRes, err
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [1]string
-	pathParts[0] = "/api/build-info"
+	pathParts[0] = "/build-info"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	stage = "EncodeRequest"

--- a/server/admin/openapi/oas_handlers_gen.go
+++ b/server/admin/openapi/oas_handlers_gen.go
@@ -803,14 +803,14 @@ func (s *Server) handleGetAllEntryTitlesRequest(args [0]string, argsEscaped bool
 
 // handleGetBuildInfoRequest handles getBuildInfo operation.
 //
-// GET /api/build-info
+// GET /build-info
 func (s *Server) handleGetBuildInfoRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
 		otelogen.OperationID("getBuildInfo"),
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.HTTPRouteKey.String("/api/build-info"),
+		semconv.HTTPRouteKey.String("/build-info"),
 	}
 
 	// Start a span for this request.

--- a/server/admin/openapi/oas_router_gen.go
+++ b/server/admin/openapi/oas_router_gen.go
@@ -61,9 +61,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 			switch elem[0] {
-			case 'a': // Prefix: "a"
+			case 'a': // Prefix: "auth/"
 
-				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
+				if l := len("auth/"); len(elem) >= l && elem[0:l] == "auth/" {
 					elem = elem[l:]
 				} else {
 					break
@@ -73,9 +73,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					break
 				}
 				switch elem[0] {
-				case 'p': // Prefix: "pi/build-info"
+				case 'c': // Prefix: "check"
 
-					if l := len("pi/build-info"); len(elem) >= l && elem[0:l] == "pi/build-info" {
+					if l := len("check"); len(elem) >= l && elem[0:l] == "check" {
 						elem = elem[l:]
 					} else {
 						break
@@ -85,7 +85,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						// Leaf node.
 						switch r.Method {
 						case "GET":
-							s.handleGetBuildInfoRequest([0]string{}, elemIsEscaped, w, r)
+							s.handleAuthCheckRequest([0]string{}, elemIsEscaped, w, r)
 						default:
 							s.notAllowed(w, r, "GET")
 						}
@@ -93,9 +93,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-				case 'u': // Prefix: "uth/"
+				case 'l': // Prefix: "log"
 
-					if l := len("uth/"); len(elem) >= l && elem[0:l] == "uth/" {
+					if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
 						elem = elem[l:]
 					} else {
 						break
@@ -105,9 +105,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						break
 					}
 					switch elem[0] {
-					case 'c': // Prefix: "check"
+					case 'i': // Prefix: "in"
 
-						if l := len("check"); len(elem) >= l && elem[0:l] == "check" {
+						if l := len("in"); len(elem) >= l && elem[0:l] == "in" {
 							elem = elem[l:]
 						} else {
 							break
@@ -116,71 +116,57 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						if len(elem) == 0 {
 							// Leaf node.
 							switch r.Method {
-							case "GET":
-								s.handleAuthCheckRequest([0]string{}, elemIsEscaped, w, r)
+							case "POST":
+								s.handleAuthLoginRequest([0]string{}, elemIsEscaped, w, r)
 							default:
-								s.notAllowed(w, r, "GET")
+								s.notAllowed(w, r, "POST")
 							}
 
 							return
 						}
 
-					case 'l': // Prefix: "log"
+					case 'o': // Prefix: "out"
 
-						if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
+						if l := len("out"); len(elem) >= l && elem[0:l] == "out" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							break
-						}
-						switch elem[0] {
-						case 'i': // Prefix: "in"
-
-							if l := len("in"); len(elem) >= l && elem[0:l] == "in" {
-								elem = elem[l:]
-							} else {
-								break
+							// Leaf node.
+							switch r.Method {
+							case "POST":
+								s.handleAuthLogoutRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, "POST")
 							}
 
-							if len(elem) == 0 {
-								// Leaf node.
-								switch r.Method {
-								case "POST":
-									s.handleAuthLoginRequest([0]string{}, elemIsEscaped, w, r)
-								default:
-									s.notAllowed(w, r, "POST")
-								}
-
-								return
-							}
-
-						case 'o': // Prefix: "out"
-
-							if l := len("out"); len(elem) >= l && elem[0:l] == "out" {
-								elem = elem[l:]
-							} else {
-								break
-							}
-
-							if len(elem) == 0 {
-								// Leaf node.
-								switch r.Method {
-								case "POST":
-									s.handleAuthLogoutRequest([0]string{}, elemIsEscaped, w, r)
-								default:
-									s.notAllowed(w, r, "POST")
-								}
-
-								return
-							}
-
+							return
 						}
 
 					}
 
+				}
+
+			case 'b': // Prefix: "build-info"
+
+				if l := len("build-info"); len(elem) >= l && elem[0:l] == "build-info" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch r.Method {
+					case "GET":
+						s.handleGetBuildInfoRequest([0]string{}, elemIsEscaped, w, r)
+					default:
+						s.notAllowed(w, r, "GET")
+					}
+
+					return
 				}
 
 			case 'e': // Prefix: "entr"
@@ -579,9 +565,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				break
 			}
 			switch elem[0] {
-			case 'a': // Prefix: "a"
+			case 'a': // Prefix: "auth/"
 
-				if l := len("a"); len(elem) >= l && elem[0:l] == "a" {
+				if l := len("auth/"); len(elem) >= l && elem[0:l] == "auth/" {
 					elem = elem[l:]
 				} else {
 					break
@@ -591,9 +577,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					break
 				}
 				switch elem[0] {
-				case 'p': // Prefix: "pi/build-info"
+				case 'c': // Prefix: "check"
 
-					if l := len("pi/build-info"); len(elem) >= l && elem[0:l] == "pi/build-info" {
+					if l := len("check"); len(elem) >= l && elem[0:l] == "check" {
 						elem = elem[l:]
 					} else {
 						break
@@ -603,10 +589,10 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						// Leaf node.
 						switch method {
 						case "GET":
-							r.name = GetBuildInfoOperation
-							r.summary = ""
-							r.operationID = "getBuildInfo"
-							r.pathPattern = "/api/build-info"
+							r.name = AuthCheckOperation
+							r.summary = "Check if user is authenticated"
+							r.operationID = "Auth_check"
+							r.pathPattern = "/auth/check"
 							r.args = args
 							r.count = 0
 							return r, true
@@ -615,9 +601,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-				case 'u': // Prefix: "uth/"
+				case 'l': // Prefix: "log"
 
-					if l := len("uth/"); len(elem) >= l && elem[0:l] == "uth/" {
+					if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
 						elem = elem[l:]
 					} else {
 						break
@@ -627,9 +613,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						break
 					}
 					switch elem[0] {
-					case 'c': // Prefix: "check"
+					case 'i': // Prefix: "in"
 
-						if l := len("check"); len(elem) >= l && elem[0:l] == "check" {
+						if l := len("in"); len(elem) >= l && elem[0:l] == "in" {
 							elem = elem[l:]
 						} else {
 							break
@@ -638,11 +624,11 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						if len(elem) == 0 {
 							// Leaf node.
 							switch method {
-							case "GET":
-								r.name = AuthCheckOperation
-								r.summary = "Check if user is authenticated"
-								r.operationID = "Auth_check"
-								r.pathPattern = "/auth/check"
+							case "POST":
+								r.name = AuthLoginOperation
+								r.summary = "Login with username and password"
+								r.operationID = "Auth_login"
+								r.pathPattern = "/auth/login"
 								r.args = args
 								r.count = 0
 								return r, true
@@ -651,70 +637,56 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							}
 						}
 
-					case 'l': // Prefix: "log"
+					case 'o': // Prefix: "out"
 
-						if l := len("log"); len(elem) >= l && elem[0:l] == "log" {
+						if l := len("out"); len(elem) >= l && elem[0:l] == "out" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							break
-						}
-						switch elem[0] {
-						case 'i': // Prefix: "in"
-
-							if l := len("in"); len(elem) >= l && elem[0:l] == "in" {
-								elem = elem[l:]
-							} else {
-								break
+							// Leaf node.
+							switch method {
+							case "POST":
+								r.name = AuthLogoutOperation
+								r.summary = "Logout and invalidate session"
+								r.operationID = "Auth_logout"
+								r.pathPattern = "/auth/logout"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
 							}
-
-							if len(elem) == 0 {
-								// Leaf node.
-								switch method {
-								case "POST":
-									r.name = AuthLoginOperation
-									r.summary = "Login with username and password"
-									r.operationID = "Auth_login"
-									r.pathPattern = "/auth/login"
-									r.args = args
-									r.count = 0
-									return r, true
-								default:
-									return
-								}
-							}
-
-						case 'o': // Prefix: "out"
-
-							if l := len("out"); len(elem) >= l && elem[0:l] == "out" {
-								elem = elem[l:]
-							} else {
-								break
-							}
-
-							if len(elem) == 0 {
-								// Leaf node.
-								switch method {
-								case "POST":
-									r.name = AuthLogoutOperation
-									r.summary = "Logout and invalidate session"
-									r.operationID = "Auth_logout"
-									r.pathPattern = "/auth/logout"
-									r.args = args
-									r.count = 0
-									return r, true
-								default:
-									return
-								}
-							}
-
 						}
 
 					}
 
+				}
+
+			case 'b': // Prefix: "build-info"
+
+				if l := len("build-info"); len(elem) >= l && elem[0:l] == "build-info" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch method {
+					case "GET":
+						r.name = GetBuildInfoOperation
+						r.summary = ""
+						r.operationID = "getBuildInfo"
+						r.pathPattern = "/build-info"
+						r.args = args
+						r.count = 0
+						return r, true
+					default:
+						return
+					}
 				}
 
 			case 'e': // Prefix: "entr"

--- a/server/admin/openapi/oas_server_gen.go
+++ b/server/admin/openapi/oas_server_gen.go
@@ -46,7 +46,7 @@ type Handler interface {
 	GetAllEntryTitles(ctx context.Context) (GetAllEntryTitlesRes, error)
 	// GetBuildInfo implements getBuildInfo operation.
 	//
-	// GET /api/build-info
+	// GET /build-info
 	GetBuildInfo(ctx context.Context) (GetBuildInfoRes, error)
 	// GetEntryByDynamicPath implements getEntryByDynamicPath operation.
 	//

--- a/server/admin/openapi/oas_unimplemented_gen.go
+++ b/server/admin/openapi/oas_unimplemented_gen.go
@@ -69,7 +69,7 @@ func (UnimplementedHandler) GetAllEntryTitles(ctx context.Context) (r GetAllEntr
 
 // GetBuildInfo implements getBuildInfo operation.
 //
-// GET /api/build-info
+// GET /build-info
 func (UnimplementedHandler) GetBuildInfo(ctx context.Context) (r GetBuildInfoRes, _ error) {
 	return r, ht.ErrNotImplemented
 }

--- a/server/config.go
+++ b/server/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	AdminUser     string `env:"ADMIN_USER"   envDefault:"admin"`
 	AdminPassword string `env:"ADMIN_PW"`
 
+	AllowedOrigins []string `env:"ALLOWED_ORIGINS" envSeparator:","`
+
 	HubUrls string `env:"HUB_URLS"`
 
 	AmazonPaapi5AccessKey string `env:"AMAZON_PAAPI5_ACCESS_KEY"`

--- a/typespec/routes/build-info.tsp
+++ b/typespec/routes/build-info.tsp
@@ -7,7 +7,7 @@ using OpenAPI;
 
 namespace AdminAPI;
 
-@route("/api/build-info")
+@route("/build-info")
 namespace BuildInfo {
   model BuildInfo {
     buildTime: string;

--- a/web/admin/src/generated-client/index.ts
+++ b/web/admin/src/generated-client/index.ts
@@ -42,43 +42,6 @@ export type HTTPStatusCode4xx = 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 
 export type HTTPStatusCode5xx = 500 | 501 | 502 | 503 | 504 | 505 | 507 | 511;
 export type HTTPStatusCodes = HTTPStatusCode1xx | HTTPStatusCode2xx | HTTPStatusCode3xx | HTTPStatusCode4xx | HTTPStatusCode5xx;
 
-export type getBuildInfoResponse200 = {
-  data: BuildInfoBuildInfo
-  status: 200
-}
-
-export type getBuildInfoResponse500 = {
-  data: ErrorResponse
-  status: 500
-}
-    
-export type getBuildInfoResponseComposite = getBuildInfoResponse200 | getBuildInfoResponse500;
-    
-export type getBuildInfoResponse = getBuildInfoResponseComposite & {
-  headers: Headers;
-}
-
-export const getGetBuildInfoUrl = () => {
-
-
-  
-
-  return `/api/build-info`
-}
-
-export const getBuildInfo = async ( options?: RequestInit): Promise<getBuildInfoResponse> => {
-  
-  return customInstance<getBuildInfoResponse>(getGetBuildInfoUrl(),
-  {      
-    ...options,
-    method: 'GET'
-    
-    
-  }
-);}
-
-
-
 /**
  * @summary Check if user is authenticated
  */
@@ -193,6 +156,43 @@ export const authLogout = async ( options?: RequestInit): Promise<authLogoutResp
   {      
     ...options,
     method: 'POST'
+    
+    
+  }
+);}
+
+
+
+export type getBuildInfoResponse200 = {
+  data: BuildInfoBuildInfo
+  status: 200
+}
+
+export type getBuildInfoResponse500 = {
+  data: ErrorResponse
+  status: 500
+}
+    
+export type getBuildInfoResponseComposite = getBuildInfoResponse200 | getBuildInfoResponse500;
+    
+export type getBuildInfoResponse = getBuildInfoResponseComposite & {
+  headers: Headers;
+}
+
+export const getGetBuildInfoUrl = () => {
+
+
+  
+
+  return `/build-info`
+}
+
+export const getBuildInfo = async ( options?: RequestInit): Promise<getBuildInfoResponse> => {
+  
+  return customInstance<getBuildInfoResponse>(getGetBuildInfoUrl(),
+  {      
+    ...options,
+    method: 'GET'
     
     
   }


### PR DESCRIPTION
CORSの許可オリジンを環境変数 `ALLOWED_ORIGINS` で設定できるように変更しました。

これにより、ローカル開発環境 (`LocalDev`) の設定とCORSの設定が分離され、より柔軟な設定が可能になります。

主な変更点:
- `server/config.go`: `AllowedOrigins` を追加
- `internal/admin/admin.go`: `AllowedOrigins` を使用してCORSを設定
- `docker-compose.yml`: `ALLOWED_ORIGINS` を環境変数として追加