### PR TITLE
refactor: CORS設定をLocalDevから分離

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       # Application configuration
       BLOG_PORT: 8181
       LOCAL_DEV: true
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:6173}
       ADMIN_USER: ${ADMIN_USER:-admin}
       ADMIN_PW: ${ADMIN_PASSWORD:-admin}
       

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -33,10 +33,10 @@ func Router(cfg server.Config, db *sql.DB, sobsClient *sobs.SobsClient) (*chi.Mu
 
 	r := chi.NewRouter()
 	//r.Use(middleware.BasicAuth("admin", map[string]string{cfg.AdminUser: cfg.AdminPassword}))
-	if cfg.LocalDev {
-		slog.Info("LocalDevelopment mode enabled. CORS is allowed", slog.String("origin", "http://localhost:6173"))
+	if len(cfg.AllowedOrigins) > 0 {
+		slog.Info("CORS is allowed", slog.Any("origins", cfg.AllowedOrigins))
 		r.Use(cors.Handler(cors.Options{
-			AllowedOrigins:   []string{"http://localhost:6173"},
+			AllowedOrigins:   cfg.AllowedOrigins,
 			AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 			AllowCredentials: true,

--- a/server/config.go
+++ b/server/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	AdminUser     string `env:"ADMIN_USER"   envDefault:"admin"`
 	AdminPassword string `env:"ADMIN_PW"`
 
+	AllowedOrigins []string `env:"ALLOWED_ORIGINS" envSeparator:","`
+
 	HubUrls string `env:"HUB_URLS"`
 
 	AmazonPaapi5AccessKey string `env:"AMAZON_PAAPI5_ACCESS_KEY"`


### PR DESCRIPTION
CORSの許可オリジンを環境変数 `ALLOWED_ORIGINS` で設定できるように変更しました。

これにより、ローカル開発環境 (`LocalDev`) の設定とCORSの設定が分離され、より柔軟な設定が可能になります。

主な変更点:
- `server/config.go`: `AllowedOrigins` を追加
- `internal/admin/admin.go`: `AllowedOrigins` を使用してCORSを設定
- `docker-compose.yml`: `ALLOWED_ORIGINS` を環境変数として追加