### PR TITLE
fix: update Renovate config to properly handle pnpm lockfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,17 @@
   "extends": [
     "config:recommended"
   ],
-  "automerge": true
+  "automerge": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "pnpmDedupe"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enable lockFileMaintenance to ensure lockfiles are updated with package changes
- Add pnpmDedupe postUpdateOption to optimize lockfile after updates
- Set rangeStrategy to bump for npm packages to ensure proper version updates

## Context
This fixes the issue where pnpm-lock.yaml wasn't being updated in Renovate PRs, causing CI failures like in PR #319.

The current Renovate configuration was missing specific settings for pnpm lockfile handling, which resulted in PRs that updated package.json but not the corresponding pnpm-lock.yaml file.

## Test plan
- [ ] Renovate bot should update both package.json and pnpm-lock.yaml in future PRs
- [ ] CI checks should pass when dependencies are updated
- [ ] PR #319 can be closed/rebased after this is merged

🤖 Generated with [Claude Code](https://claude.ai/code)