### PR TITLE
feat: add Claude MCP configuration for Playwright

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,10 @@
       "Bash(goimports:*)",
       "Bash(mkdir:*)",
       "WebFetch(domain:localhost)",
-      "Bash(git restore:*)"
+      "Bash(git restore:*)",
+      "Bash(npx @modelcontextprotocol/server-playwright:*)",
+      "mcp__playwright__browser_navigate",
+      "mcp__playwright__browser_install"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary
- Add Claude MCP (Model Context Protocol) configuration for Playwright integration
- Enable permissions for Playwright browser automation tools

## Test plan
- [x] Configuration file added successfully
- [ ] MCP server integration tested in new Claude conversation

🤖 Generated with [Claude Code](https://claude.ai/code)