### PR TITLE
fix: set VITE_API_BASE_URL in Dockerfile for production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY web/admin/package.json web/admin/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/admin/ ./
+ENV VITE_API_BASE_URL=/admin/api
 RUN pnpm run build
 
 # Stage 2: Build the Go backend


### PR DESCRIPTION
## Summary
- Set VITE_API_BASE_URL environment variable to `/admin/api` during frontend build in Dockerfile
- This fixes the issue where production builds were trying to access localhost:8181 instead of the correct API endpoint

## Test plan
- [ ] Build Docker image with `task docker-build`
- [ ] Verify that the frontend correctly calls `/admin/api` endpoints instead of localhost:8181
- [ ] Check that the admin interface works properly in the Docker container

🤖 Generated with [Claude Code](https://claude.ai/code)