### PR TITLE
test: add e2e test for issue #330 - verify 'c' key in search form

### DIFF
--- a/web/admin/e2e/top-page.spec.ts
+++ b/web/admin/e2e/top-page.spec.ts
@@ -68,6 +68,27 @@ test.describe("Admin Top Page", () => {
 		expect(titleValue).toContain(new Date().getFullYear().toString());
 	});
 
+	test("should NOT create new entry when typing 'c' in search box", async ({ page }) => {
+		// Focus on search box
+		const searchBox = page.getByPlaceholder("Search entries...");
+		await searchBox.focus();
+
+		// Type 'c' in the search box
+		await searchBox.type("c");
+
+		// Wait a moment to ensure no navigation happens
+		await page.waitForTimeout(500);
+
+		// Should still be on the admin page
+		await expect(page).toHaveURL("/admin");
+
+		// Search box should contain 'c'
+		await expect(searchBox).toHaveValue("c");
+
+		// Should not have navigated to a new entry page
+		await expect(page).not.toHaveURL(/\/admin\/entry\/.+/);
+	});
+
 	test("should create new entry using NEW button", async ({ page }) => {
 		// Click New Entry button
 		await page.getByRole("button", { name: "New Entry" }).click();


### PR DESCRIPTION
## Summary
Added an e2e test to verify that typing 'c' in the search form doesn't create a new entry.

## Issue
Fixes #330 - 検索フォームの中で c とうつとエントリが作成される

## Test Details
The new test case `should NOT create new entry when typing 'c' in search box` verifies:
1. Focus on the search box
2. Type 'c' in the search field
3. Confirm that no navigation to a new entry occurs
4. Confirm that the search box contains 'c'
5. Confirm that we're still on the admin page

This ensures that the keyboard shortcut only works when not focused on input fields.

🤖 Generated with [Claude Code](https://claude.ai/code)