### PR TITLE
feat: optimize CI pipeline by splitting Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,6 @@ jobs:
       - name: Run Go tests
         run: go test ./...
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
-        run: docker build -t blog4 .
-
   check-generated-files:
     runs-on: ubuntu-latest
 
@@ -157,3 +151,17 @@ jobs:
             git status --porcelain
             exit 1
           fi
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [lint-and-test]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: docker build -t blog4 .


### PR DESCRIPTION
## Summary
- Split Docker build into a separate CI job to reduce lint-and-test execution time
- Docker build now runs in parallel with check-generated-files after lint-and-test completes
- This should reduce the lint-and-test job time from ~3+ minutes to ~2 minutes

## Changes
- Removed Docker build steps from `lint-and-test` job
- Created new `docker-build` job that depends only on `lint-and-test`
- Docker build can now run in parallel with `check-generated-files`

## Test plan
- [ ] CI passes on this PR
- [ ] All three jobs complete successfully
- [ ] Verify lint-and-test completes faster than before

🤖 Generated with [Claude Code](https://claude.ai/code)