### PR TITLE
feat: add htmx login page

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -107,7 +107,7 @@ func Router(cfg server.Config, db *sql.DB, sobsClient *sobs.SobsClient) (*chi.Mu
 	r.Mount("/api/", apiRouter)
 
 	// htmx routes with gin and session middleware
-	htmxRouter := SetupHtmxRouter(queries)
+	htmxRouter := SetupHtmxRouter(queries, cfg)
 	r.Mount("/htmx/", htmxRouter)
 
 	return r, nil

--- a/web/static/admin/login.css
+++ b/web/static/admin/login.css
@@ -1,0 +1,130 @@
+/* Login page specific styles */
+
+.login-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.login-box {
+    background: white;
+    padding: 40px;
+    border-radius: 8px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+    width: 100%;
+    max-width: 400px;
+}
+
+.login-box h1 {
+    margin: 0 0 24px 0;
+    font-size: 24px;
+    font-weight: 600;
+    text-align: center;
+    color: #333;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #555;
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"] {
+    width: 100%;
+    padding: 12px 16px;
+    font-size: 16px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-group input[type="text"]:focus,
+.form-group input[type="password"]:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102,126,234,0.1);
+}
+
+.checkbox-group {
+    margin-top: 16px;
+}
+
+.checkbox-group label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.checkbox-group input[type="checkbox"] {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+.checkbox-group span {
+    font-size: 14px;
+    color: #666;
+    user-select: none;
+}
+
+.btn-login {
+    width: 100%;
+    padding: 14px;
+    font-size: 16px;
+    font-weight: 600;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    margin-top: 8px;
+}
+
+.btn-login:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102,126,234,0.4);
+}
+
+.btn-login:active {
+    transform: translateY(0);
+}
+
+.error-message {
+    min-height: 20px;
+    margin-bottom: 16px;
+}
+
+.error-message:not(:empty) {
+    padding: 12px 16px;
+    background: #fee;
+    color: #c33;
+    border: 1px solid #fcc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+/* Loading state */
+.htmx-request .btn-login {
+    opacity: 0.7;
+    cursor: wait;
+}
+
+.htmx-request .btn-login::after {
+    content: '...';
+    animation: dots 1.5s steps(3, end) infinite;
+}
+
+@keyframes dots {
+    0%, 20% { content: '.'; }
+    40% { content: '..'; }
+    60%, 100% { content: '...'; }
+}

--- a/web/templates/admin/htmx_login.html
+++ b/web/templates/admin/htmx_login.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Login</title>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="/admin/htmx/static/common.css">
+    <link rel="stylesheet" href="/admin/htmx/static/login.css">
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-box">
+            <h1>Admin Login</h1>
+
+            <div id="error-message" class="error-message"></div>
+
+            <form hx-post="/admin/htmx/login"
+                  hx-target="#error-message"
+                  hx-swap="innerHTML">
+                <div class="form-group">
+                    <label for="username">Username</label>
+                    <input
+                        type="text"
+                        id="username"
+                        name="username"
+                        required
+                        autofocus
+                        autocomplete="username">
+                </div>
+
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input
+                        type="password"
+                        id="password"
+                        name="password"
+                        required
+                        autocomplete="current-password">
+                </div>
+
+                <div class="form-group checkbox-group">
+                    <label>
+                        <input type="checkbox" name="remember_me" value="true">
+                        <span>Remember me for 30 days</span>
+                    </label>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-login">
+                    Login
+                </button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## 概要

htmx admin のログインページを実装しました。

## 機能

- シンプルで美しいログインフォーム (グラデーション UI)
- Username/Password 認証
- "Remember me" チェックボックス (30日間 vs 通常セッション)
- セキュアなパスワード比較 (constant-time comparison)
- セッション Cookie の作成
- htmx ベースのフォーム送信でエラー表示

## スクリーンショット

ログインフォームは Material-UI 風のデザインで:
- グラデーション背景 (紫〜青)
- 中央配置の白いカードデザイン
- フォーカス時のアニメーション
- エラーメッセージのインライン表示

## 実装詳細

### ルーティング
```go
// Login routes (no session middleware)
router.GET("/htmx/login", handler.RenderLoginPage)
router.POST("/htmx/login", handler.HandleLogin)

// Session middleware applied after login routes
router.Use(GinSessionMiddleware(queries))
```

ログインページはセッション middleware の前に配置することで、未認証でもアクセス可能。

### ログイン処理フロー
1. Username/Password を constant-time comparison で検証
2. セッション ID を生成
3. Remember me に応じてセッション有効期限を設定 (7日 or 30日)
4. DB にセッションを保存
5. Cookie を設定
6. `HX-Redirect` header で `/admin/htmx/entries` にリダイレクト

### セキュリティ
- `crypto/subtle.ConstantTimeCompare` でタイミング攻撃対策
- HttpOnly, Secure, SameSite=Strict の Cookie
- セッション有効期限の管理

## ファイル

- `web/templates/admin/htmx_login.html`: ログインページテンプレート
- `web/static/admin/login.css`: ログインページ用スタイル
- `internal/admin/htmx_handlers.go`: ログインハンドラ追加
- `internal/admin/htmx_router.go`: ログインルート追加
- `internal/admin/admin.go`: config を SetupHtmxRouter に渡す

## テスト

- `go build ./cmd/blog4` ✅ ビルド成功
- ログインフローの動作確認 (手動テスト推奨)

## 次のステップ

これで htmx admin の基本機能が揃いました:
- ✅ ログインページ
- ✅ エントリ一覧
- ✅ エントリ編集

追加で実装可能な機能:
- ログアウト機能
- セッション管理ページ
- その他の管理機能