### PR TITLE
fix: use query parameters for admin entry routes

### DIFF
--- a/internal/admin/htmx_handlers.go
+++ b/internal/admin/htmx_handlers.go
@@ -33,17 +33,11 @@ func NewHtmxHandler(queries *admindb.Queries, adminUser, adminPassword string, i
 	}
 }
 
-// getEntryPath extracts and constructs the entry path from gin context params
+// getEntryPath extracts the entry path from query parameter
+// For /entries/edit?path=getting-started -> returns "getting-started"
+// For /entries/edit?path=2024/01/01/120000 -> returns "2024/01/01/120000"
 func getEntryPath(c *gin.Context) string {
-	year := c.Param("year")
-	month := c.Param("month")
-	day := c.Param("day")
-	time := c.Param("time")
-
-	if year != "" && month != "" && day != "" && time != "" {
-		return year + "/" + month + "/" + day + "/" + time
-	}
-	return c.Param("path")
+	return c.Query("path")
 }
 
 type HtmxEntriesData struct {
@@ -311,7 +305,7 @@ func (h *HtmxHandler) CreateEntry(c *gin.Context) {
 		return
 	}
 
-	c.Header("HX-Redirect", "/admin/entries/"+path+"/edit")
+	c.Header("HX-Redirect", "/admin/entries/edit?path="+path)
 	c.Status(200)
 }
 

--- a/internal/admin/htmx_router.go
+++ b/internal/admin/htmx_router.go
@@ -93,16 +93,14 @@ func SetupHtmxRouter(queries *admindb.Queries, cfg server.Config) http.Handler {
 	router.GET("/entries/search", handler.RenderEntriesPage)
 	router.POST("/entries/create", handler.CreateEntry)
 
-	// Entry routes with path parameters (yyyy/mm/dd/hhmmss format)
-	entries := router.Group("/entries/:year/:month/:day/:time")
-	{
-		entries.GET("/edit", handler.RenderEntryEditPage)
-		entries.POST("/title", handler.UpdateEntryTitle)
-		entries.POST("/body", handler.UpdateEntryBody)
-		entries.POST("/visibility", handler.UpdateEntryVisibility)
-		entries.POST("/image/regenerate", handler.RegenerateEntryImage)
-		entries.DELETE("", handler.DeleteEntry)
-	}
+	// Entry routes with query parameter (supports both slug and date-based paths)
+	// Examples: /entries/edit?path=getting-started, /entries/edit?path=2024/01/01/120000
+	router.GET("/entries/edit", handler.RenderEntryEditPage)
+	router.POST("/entries/title", handler.UpdateEntryTitle)
+	router.POST("/entries/body", handler.UpdateEntryBody)
+	router.POST("/entries/visibility", handler.UpdateEntryVisibility)
+	router.POST("/entries/image/regenerate", handler.RegenerateEntryImage)
+	router.DELETE("/entries/delete", handler.DeleteEntry)
 
 	// Static files
 	router.Static("/static", "web/static/admin")

--- a/web/templates/admin/htmx_entry_cards.html
+++ b/web/templates/admin/htmx_entry_cards.html
@@ -1,6 +1,6 @@
 {{define "entry-cards"}}
 {{range .Entries}}
-<a href="/admin/entries/{{.Path}}/edit"
+<a href="/admin/entries/edit?path={{.Path}}"
    class="entry-card {{if eq .Visibility "private"}}private{{end}}"
    hx-boost="true">
     <div class="entry-card-content">

--- a/web/templates/admin/htmx_entry_edit.html
+++ b/web/templates/admin/htmx_entry_edit.html
@@ -21,7 +21,7 @@
                     value="{{.Title}}"
                     placeholder="Entry Title"
                     class="title-input"
-                    hx-post="/admin/entries/{{.Path}}/title"
+                    hx-post="/admin/entries/title?path={{.Path}}"
                     hx-trigger="keyup changed delay:500ms"
                     hx-target="#save-feedback"
                     hx-swap="innerHTML"
@@ -34,7 +34,7 @@
                     name="body"
                     placeholder="Write your markdown here..."
                     class="body-textarea"
-                    hx-post="/admin/entries/{{.Path}}/body"
+                    hx-post="/admin/entries/body?path={{.Path}}"
                     hx-trigger="keyup changed delay:800ms"
                     hx-target="#save-feedback"
                     hx-swap="innerHTML"
@@ -56,7 +56,7 @@
                             name="visibility"
                             value="private"
                             {{if eq .Visibility "private"}}checked{{end}}
-                            hx-post="/admin/entries/{{.Path}}/visibility"
+                            hx-post="/admin/entries/visibility?path={{.Path}}"
                             hx-target="#save-feedback"
                             hx-confirm="Change visibility to private?"
                         />
@@ -68,7 +68,7 @@
                             name="visibility"
                             value="public"
                             {{if eq .Visibility "public"}}checked{{end}}
-                            hx-post="/admin/entries/{{.Path}}/visibility"
+                            hx-post="/admin/entries/visibility?path={{.Path}}"
                             hx-target="#save-feedback"
                             hx-confirm="Change visibility to public?"
                         />
@@ -82,13 +82,13 @@
                 <h3>Actions</h3>
                 <button
                     class="btn btn-danger"
-                    hx-delete="/admin/entries/{{.Path}}"
+                    hx-delete="/admin/entries/delete?path={{.Path}}"
                     hx-confirm="Are you sure you want to delete this entry? This action cannot be undone.">
                     🗑 Delete Entry
                 </button>
                 <button
                     class="btn btn-secondary"
-                    hx-post="/admin/entries/{{.Path}}/image/regenerate"
+                    hx-post="/admin/entries/image/regenerate?path={{.Path}}"
                     hx-target="#save-feedback"
                     hx-swap="innerHTML">
                     🔄 Regenerate Image


### PR DESCRIPTION
## Summary
Changed admin entry routes from wildcard paths to query parameters for better clarity and to avoid issues with complex path handling.

## Changes
- Routes now use `?path=<entry-path>` query parameter format
- Examples: `/entries/edit?path=getting-started`, `/entries/edit?path=2024/01/01/120000`
- Supports both slug-based and date-based entry paths
- Updated all templates to use new URL format
- Simplified `getEntryPath` function to read from query params

## Affected Routes
- GET `/entries/edit?path=<path>`
- POST `/entries/title?path=<path>`
- POST `/entries/body?path=<path>`
- POST `/entries/visibility?path=<path>`
- POST `/entries/image/regenerate?path=<path>`
- DELETE `/entries/delete?path=<path>`

## Files Modified
- `internal/admin/htmx_router.go` - Updated route definitions
- `internal/admin/htmx_handlers.go` - Simplified `getEntryPath` function
- `web/templates/admin/htmx_entry_cards.html` - Updated entry card links
- `web/templates/admin/htmx_entry_edit.html` - Updated all htmx action URLs

## Test Plan
- [x] Entry list page loads correctly
- [ ] Clicking on entry card navigates to edit page
- [ ] Editing title saves properly
- [ ] Editing body saves properly
- [ ] Changing visibility works
- [ ] Delete entry works
- [ ] Regenerate image works