### PR TITLE
feat(public): client-side full-text search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ docker-build:
 
 # Run biome check (lint and format check) via Docker
 biome-check:
-	docker run --rm -v $(PWD):/app -w /app ghcr.io/biomejs/biome:latest check admin/static/sw.js
+	docker run --rm -v $(PWD):/app -w /app ghcr.io/biomejs/biome:latest check admin/static/sw.js public/static/search.js
 
 # Run biome fix (lint and format fix) via Docker
 biome-fix:
-	docker run --rm -v $(PWD):/app -w /app ghcr.io/biomejs/biome:latest check --write admin/static/sw.js
+	docker run --rm -v $(PWD):/app -w /app ghcr.io/biomejs/biome:latest check --write admin/static/sw.js public/static/search.js
 
 # Access MariaDB console as blog4user
 db:

--- a/db/public/publicdb/public.sql.go
+++ b/db/public/publicdb/public.sql.go
@@ -10,78 +10,6 @@ import (
 	"database/sql"
 )
 
-const fullTextSearchEntries = `-- name: FullTextSearchEntries :many
-SELECT entry.path, entry.title, entry.body, entry.visibility, entry.format, entry.published_at, entry.last_edited_at, entry.created_at, entry.updated_at, entry_image.url image_url,
-       MATCH(entry.title, entry.body) AGAINST(? IN NATURAL LANGUAGE MODE) AS relevance
-FROM entry
-    LEFT JOIN entry_image ON (entry.path = entry_image.path)
-WHERE visibility = 'public'
-  AND MATCH(entry.title, entry.body) AGAINST(? IN NATURAL LANGUAGE MODE)
-ORDER BY relevance DESC
-LIMIT ? OFFSET ?
-`
-
-type FullTextSearchEntriesParams struct {
-	Column1 string
-	Column2 string
-	Limit   int32
-	Offset  int32
-}
-
-type FullTextSearchEntriesRow struct {
-	Path         string
-	Title        string
-	Body         string
-	Visibility   EntryVisibility
-	Format       EntryFormat
-	PublishedAt  sql.NullTime
-	LastEditedAt sql.NullTime
-	CreatedAt    sql.NullTime
-	UpdatedAt    sql.NullTime
-	ImageUrl     sql.NullString
-	Relevance    interface{}
-}
-
-func (q *Queries) FullTextSearchEntries(ctx context.Context, arg FullTextSearchEntriesParams) ([]FullTextSearchEntriesRow, error) {
-	rows, err := q.db.QueryContext(ctx, fullTextSearchEntries,
-		arg.Column1,
-		arg.Column2,
-		arg.Limit,
-		arg.Offset,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []FullTextSearchEntriesRow
-	for rows.Next() {
-		var i FullTextSearchEntriesRow
-		if err := rows.Scan(
-			&i.Path,
-			&i.Title,
-			&i.Body,
-			&i.Visibility,
-			&i.Format,
-			&i.PublishedAt,
-			&i.LastEditedAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.ImageUrl,
-			&i.Relevance,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getAsin = `-- name: GetAsin :one
 SELECT asin, title, image_medium_url, link, created_at
 FROM amazon_cache
@@ -275,6 +203,61 @@ func (q *Queries) GetRelatedEntries3(ctx context.Context, dstTitle string) ([]En
 			&i.LastEditedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAllPublicEntries = `-- name: ListAllPublicEntries :many
+SELECT entry.path, entry.title, entry.body, entry.visibility, entry.format, entry.published_at, entry.last_edited_at, entry.created_at, entry.updated_at, entry_image.url image_url
+FROM entry
+    LEFT JOIN entry_image ON (entry.path = entry_image.path)
+WHERE visibility = 'public'
+ORDER BY published_at DESC
+`
+
+type ListAllPublicEntriesRow struct {
+	Path         string
+	Title        string
+	Body         string
+	Visibility   EntryVisibility
+	Format       EntryFormat
+	PublishedAt  sql.NullTime
+	LastEditedAt sql.NullTime
+	CreatedAt    sql.NullTime
+	UpdatedAt    sql.NullTime
+	ImageUrl     sql.NullString
+}
+
+func (q *Queries) ListAllPublicEntries(ctx context.Context) ([]ListAllPublicEntriesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAllPublicEntries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllPublicEntriesRow
+	for rows.Next() {
+		var i ListAllPublicEntriesRow
+		if err := rows.Scan(
+			&i.Path,
+			&i.Title,
+			&i.Body,
+			&i.Visibility,
+			&i.Format,
+			&i.PublishedAt,
+			&i.LastEditedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ImageUrl,
 		); err != nil {
 			return nil, err
 		}

--- a/db/public/queries/public.sql
+++ b/db/public/queries/public.sql
@@ -47,12 +47,9 @@ WHERE entry_link.src_path IN (SELECT src_entry.title
                               WHERE entry_link.dst_title = ?)
     AND dst_entry.visibility = 'public';
 
--- name: FullTextSearchEntries :many
-SELECT entry.*, entry_image.url image_url,
-       MATCH(entry.title, entry.body) AGAINST(? IN NATURAL LANGUAGE MODE) AS relevance
+-- name: ListAllPublicEntries :many
+SELECT entry.*, entry_image.url image_url
 FROM entry
     LEFT JOIN entry_image ON (entry.path = entry_image.path)
 WHERE visibility = 'public'
-  AND MATCH(entry.title, entry.body) AGAINST(? IN NATURAL LANGUAGE MODE)
-ORDER BY relevance DESC
-LIMIT ? OFFSET ?;
+ORDER BY published_at DESC;

--- a/e2e/tests/public-search.spec.ts
+++ b/e2e/tests/public-search.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// クライアント検索 (search.js) が /search-index.json を読み、ブラウザ側で
+// 絞り込むことを検証する。MySQL FULLTEXT / MATCH AGAINST から移行した代替実装の確認。
+
+test('public search: initial query from URL renders matching entry', async ({ page }) => {
+    await page.goto('/search?q=Docker');
+    await expect(page.locator('.entry-title', { hasText: 'Docker Setup Guide' })).toBeVisible();
+});
+
+test('public search: incremental search works for Japanese keywords', async ({ page }) => {
+    await page.goto('/search');
+    // fetch 完了 (= リスナー登録 + 初期表示) を待つ
+    await expect(page.locator('#search-results')).toContainText('Enter keywords');
+    await page.locator('.search-input').fill('日本語');
+    await expect(
+        page.locator('.entry-title', { hasText: '日本語コンテンツのサンプル' }),
+    ).toBeVisible();
+});
+
+test('public search: AND of multiple terms narrows results', async ({ page }) => {
+    await page.goto('/search');
+    await expect(page.locator('#search-results')).toContainText('Enter keywords');
+    const input = page.locator('.search-input');
+    await input.fill('Docker Setup');
+    await expect(page.locator('.entry-title', { hasText: 'Docker Setup Guide' })).toBeVisible();
+    // 無関係な語を AND で足すと結果が消える
+    await input.fill('Docker zzzznotfound');
+    await expect(page.locator('#search-results')).toContainText('No results found');
+});
+
+test('public search: private entries are not searchable', async ({ page }) => {
+    await page.goto('/search');
+    await expect(page.locator('#search-results')).toContainText('Enter keywords');
+    await page.locator('.search-input').fill('Private Draft Example');
+    await page.waitForTimeout(600);
+    // private エントリは /search-index.json に含まれないので結果に出ない
+    await expect(page.getByText('Private Draft Example')).toHaveCount(0);
+});

--- a/internal/public/public.go
+++ b/internal/public/public.go
@@ -316,8 +316,7 @@ func RenderFeed(c *gin.Context, queries *publicdb.Queries) {
 	c.String(http.StatusOK, rss)
 }
 
-func RenderSearchPage(c *gin.Context, queries *publicdb.Queries) {
-	// Parse and execute the template
+func RenderSearchPage(c *gin.Context) {
 	tmpl, err := template.ParseFiles("public/templates/search.html")
 	if err != nil {
 		slog.Error("failed to parse template", slog.String("template", "search.html"), slog.Any("error", err))
@@ -325,93 +324,47 @@ func RenderSearchPage(c *gin.Context, queries *publicdb.Queries) {
 		return
 	}
 
-	// Get search query parameter
-	query := c.Query("q")
-	if query == "" {
-		// No query provided, show empty search page
-		c.Status(http.StatusOK)
-		err = tmpl.Execute(c.Writer, TopPageData{
-			Page:    1,
-			Entries: []EntryViewData{},
-			HasPrev: false,
-			HasNext: false,
-			Query:   "",
-		})
-		if err != nil {
-			slog.Error("failed to execute template", slog.String("template", "search.html"), slog.String("query", ""), slog.Any("error", err))
-			c.String(http.StatusInternalServerError, "Internal Server Error")
-		}
-		return
+	// 検索はクライアント側 (search.js) が /search-index.json を使って行う。
+	// サーバはクエリ初期値を渡す静的シェルを返すだけ。
+	c.Status(http.StatusOK)
+	if err := tmpl.Execute(c.Writer, struct{ Query string }{Query: c.Query("q")}); err != nil {
+		slog.Error("failed to execute template", slog.String("template", "search.html"), slog.Any("error", err))
+		c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
+}
 
-	// Get page number
-	page := 1
-	if pageStr := c.Query("page"); pageStr != "" {
-		page, err = strconv.Atoi(pageStr)
-		if err != nil {
-			slog.Error("failed to parse page number", slog.String("page", pageStr), slog.Any("error", err))
-			c.String(http.StatusInternalServerError, "Internal Server Error")
-			return
-		}
-	}
+// SearchIndexEntry は /search-index.json で配信する 1 エントリ分のデータ。
+type SearchIndexEntry struct {
+	Path        string `json:"path"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	PublishedAt string `json:"published_at"`
+	ImageURL    string `json:"image_url"`
+}
 
-	entriesPerPage := 60
-	offset := (page - 1) * entriesPerPage
-
-	// Perform full-text search
-	entries, err := queries.FullTextSearchEntries(c.Request.Context(), publicdb.FullTextSearchEntriesParams{
-		Column1: query,
-		Column2: query,
-		Limit:   int32(entriesPerPage + 1),
-		Offset:  int32(offset),
-	})
+// RenderSearchIndex は公開エントリ全件を JSON で返す。クライアント側の全文検索が使う。
+func RenderSearchIndex(c *gin.Context, queries *publicdb.Queries) {
+	entries, err := queries.ListAllPublicEntries(c.Request.Context())
 	if err != nil {
-		slog.Error("failed to search entries", slog.String("query", query), slog.Int("page", page), slog.Any("error", err))
+		slog.Error("failed to list public entries", slog.Any("error", err))
 		c.String(http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
 
-	// Remove last entry if there are more entries
-	var hasNext = false
-	if len(entries) > entriesPerPage {
-		entries = entries[:entriesPerPage]
-		hasNext = true
-	}
-
-	// Prepare data for the template
-	var viewData []EntryViewData
+	index := make([]SearchIndexEntry, 0, len(entries))
 	for _, entry := range entries {
-		// Format the PublishedAt date
-		var formattedDate string
+		var publishedAt string
 		if entry.PublishedAt.Valid {
-			formattedDate = entry.PublishedAt.Time.Format("2006-01-02(Mon)")
-		} else {
-			slog.Error("published_at is invalid", slog.String("path", entry.Path), slog.Any("published_at", entry.PublishedAt))
-			c.String(http.StatusInternalServerError, "Internal Server Error")
-			return
+			publishedAt = entry.PublishedAt.Time.Format("2006-01-02(Mon)")
 		}
-
-		viewData = append(viewData, EntryViewData{
+		index = append(index, SearchIndexEntry{
 			Path:        entry.Path,
 			Title:       entry.Title,
-			PublishedAt: formattedDate,
-			TextPreview: summarizeEntry(entry.Body, 100),
-			ImageUrl:    entry.ImageUrl.String,
+			Body:        entry.Body,
+			PublishedAt: publishedAt,
+			ImageURL:    entry.ImageUrl.String,
 		})
 	}
 
-	c.Status(http.StatusOK)
-	err = tmpl.Execute(c.Writer, TopPageData{
-		Page:    page,
-		Prev:    page - 1,
-		Next:    page + 1,
-		HasPrev: page > 1,
-		HasNext: hasNext,
-		Entries: viewData,
-		Query:   query,
-	})
-	if err != nil {
-		slog.Error("failed to execute template", slog.String("template", "search.html"), slog.String("query", query), slog.Int("page", page), slog.Any("error", err))
-		c.String(http.StatusInternalServerError, "Internal Server Error")
-	}
+	c.JSON(http.StatusOK, index)
 }

--- a/internal/public/public_router.go
+++ b/internal/public/public_router.go
@@ -18,8 +18,12 @@ func SetupPublicRoutes(r *gin.Engine, queries *publicdb.Queries, cfg *internal.C
 		RenderEntryPage(c, queries, cfg)
 	})
 	r.GET("/search", func(c *gin.Context) {
-		RenderSearchPage(c, queries)
+		RenderSearchPage(c)
+	})
+	r.GET("/search-index.json", func(c *gin.Context) {
+		RenderSearchIndex(c, queries)
 	})
 	r.StaticFile("/static/main.css", "public/static/main.css")
+	r.StaticFile("/static/search.js", "public/static/search.js")
 	r.StaticFile("/build-info.json", "build-info.json")
 }

--- a/internal/public/public_search_test.go
+++ b/internal/public/public_search_test.go
@@ -1,34 +1,21 @@
 package public
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSearchFormExists(t *testing.T) {
-	// Test that the search form exists in the template
-	// This test checks that the search form is properly configured
-	tmpl := getSearchTemplate()
-	assert.NotNil(t, tmpl)
-	assert.Contains(t, tmpl, `<form class="search-form" action="/search" method="GET">`)
-	assert.Contains(t, tmpl, `<input type="text" name="q" class="search-input" placeholder="Search entries..."`)
-	assert.Contains(t, tmpl, `{{.Query}}`)
-}
+func TestSearchTemplate(t *testing.T) {
+	b, err := os.ReadFile("../../public/templates/search.html")
+	assert.NoError(t, err)
+	tmpl := string(b)
 
-func getSearchTemplate() string {
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Search - tokuhirom's blog</title>
-</head>
-<body>
-    <form class="search-form" action="/search" method="GET">
-        <input type="text" name="q" class="search-input" placeholder="Search entries..." value="{{.Query}}" autofocus>
-        <button type="submit" class="search-button">Search</button>
-    </form>
-</body>
-</html>`
+	// 検索フォームの要素は残す (JS が submit を制御する)。
+	assert.Contains(t, tmpl, `<form class="search-form" action="/search" method="GET">`)
+	assert.Contains(t, tmpl, `name="q"`)
+	// クライアント検索 (search.js) が描画先とスクリプトを必要とする。
+	assert.Contains(t, tmpl, `id="search-results"`)
+	assert.Contains(t, tmpl, `/static/search.js`)
 }

--- a/public/static/search.js
+++ b/public/static/search.js
@@ -1,0 +1,143 @@
+(() => {
+    const resultsEl = document.getElementById('search-results');
+    const inputEl = document.querySelector('.search-input');
+    const formEl = document.querySelector('.search-form');
+
+    let entries = [];
+
+    // サーバの summarizeEntry 相当の軽量版: URL と [[...]] を整理して先頭 length 文字。
+    function summarize(body, length) {
+        const s = body.replace(/https?:\/\/\S+/g, '').replace(/\[\[(.*?)\]\]/g, '$1');
+        return [...s].slice(0, length).join('');
+    }
+
+    // 軽いスコアリング: 全語必須 (AND)、title ヒットを加点。
+    function scoreEntry(entry, terms) {
+        const title = entry.title.toLowerCase();
+        const body = entry.body.toLowerCase();
+        let score = 0;
+        for (const term of terms) {
+            const inTitle = title.includes(term);
+            const inBody = body.includes(term);
+            if (!inTitle && !inBody) {
+                return -1;
+            }
+            if (inTitle) {
+                score += 10;
+            }
+            if (inBody) {
+                score += 1;
+            }
+        }
+        return score;
+    }
+
+    function renderInfo(message) {
+        const div = document.createElement('div');
+        div.className = 'search-result-info';
+        div.textContent = message;
+        resultsEl.replaceChildren(div);
+    }
+
+    function renderResults(list) {
+        if (list.length === 0) {
+            renderInfo('No results found. Try different keywords.');
+            return;
+        }
+
+        const ul = document.createElement('ul');
+        ul.className = 'card-container';
+        for (const entry of list) {
+            const li = document.createElement('li');
+            li.className = 'card';
+
+            const a = document.createElement('a');
+            a.href = `/entry/${entry.path}`;
+            a.className = 'card-link';
+
+            const head = document.createElement('div');
+            head.className = 'entry-head';
+            const title = document.createElement('span');
+            title.className = 'entry-title';
+            title.textContent = entry.title;
+            head.appendChild(title);
+            a.appendChild(head);
+
+            if (entry.image_url) {
+                const wrap = document.createElement('div');
+                const img = document.createElement('img');
+                img.src = entry.image_url;
+                img.className = 'entry-image';
+                img.alt = entry.title;
+                wrap.appendChild(img);
+                a.appendChild(wrap);
+            } else {
+                const preview = document.createElement('div');
+                preview.className = 'entry-text-preview';
+                preview.textContent = summarize(entry.body, 100);
+                a.appendChild(preview);
+            }
+
+            const date = document.createElement('span');
+            date.className = 'published-date';
+            date.textContent = entry.published_at;
+            a.appendChild(date);
+
+            li.appendChild(a);
+            ul.appendChild(li);
+        }
+        resultsEl.replaceChildren(ul);
+    }
+
+    function doSearch() {
+        const q = inputEl.value.trim();
+        if (!q) {
+            renderInfo('Enter keywords to search entries.');
+            return;
+        }
+
+        const terms = q.toLowerCase().split(/\s+/).filter(Boolean);
+        const scored = [];
+        for (const entry of entries) {
+            const score = scoreEntry(entry, terms);
+            if (score >= 0) {
+                scored.push({ entry, score });
+            }
+        }
+        // 高スコア順。Array.sort は stable なので同点は元の published_at DESC を保つ。
+        scored.sort((a, b) => b.score - a.score);
+        renderResults(scored.map((x) => x.entry));
+    }
+
+    let timer = null;
+    function scheduleSearch() {
+        clearTimeout(timer);
+        timer = setTimeout(doSearch, 200);
+    }
+
+    async function init() {
+        renderInfo('Loading...');
+        try {
+            const res = await fetch('/search-index.json');
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status}`);
+            }
+            entries = await res.json();
+        } catch (err) {
+            renderInfo('Failed to load search index.');
+            console.error(err);
+            return;
+        }
+
+        inputEl.addEventListener('input', scheduleSearch);
+        formEl.addEventListener('submit', (e) => {
+            e.preventDefault();
+            doSearch();
+        });
+
+        // ?q= に初期値があれば即検索 (input の value はサーバが埋めている)。
+        doSearch();
+    }
+
+    init();
+})();

--- a/public/templates/search.html
+++ b/public/templates/search.html
@@ -78,52 +78,11 @@
     </form>
 </div>
 <div class="wrapper">
-    {{if .Entries}}
-    <ul class="card-container">
-        {{range $path, $entry := .Entries}}
-        <li class="card">
-            <a href="/entry/{{$entry.Path}}" class="card-link">
-                <div class="entry-head">
-                    <span class="entry-title">{{$entry.Title}}</span>
-                </div>
-                {{if $entry.ImageUrl}}
-                <div>
-                    <img src="{{$entry.ImageUrl}}" class="entry-image" alt="{{$entry.Title}}">
-                </div>
-                {{else}}
-                <div class="entry-text-preview">{{$entry.TextPreview}}</div>
-                {{end}}
-                <span class="published-date">{{$entry.PublishedAt}}</span>
-            </a>
-        </li>
-        {{end}}
-    </ul>
-    <div class="pager">
-        <div class="prev">
-            {{if .HasPrev}}
-            <a href="/search?q={{.Query}}&page={{.Prev}}">Prev</a>
-            {{else}}
-            Prev
-            {{end}}
-        </div>
-        <div class="next">
-            {{if .HasNext}}
-            <a href="/search?q={{.Query}}&page={{.Next}}">Next</a>
-            {{else}}
-            Next
-            {{end}}
-        </div>
+    <div id="search-results">
+        <div class="search-result-info">Loading...</div>
     </div>
-    {{else}}
-    <div class="search-result-info">
-        {{if .Query}}
-        No results found. Try different keywords.
-        {{else}}
-        Enter keywords to search entries.
-        {{end}}
-    </div>
-    {{end}}
 </div>
+<script src="/static/search.js?1"></script>
 <footer>
     &copy; tokuhirom
 </footer>


### PR DESCRIPTION
## Summary

TiDB 移行 ([migration-plan.md](architecture/migration-plan.md) フェーズ1) で使えなくなる MySQL の `FULLTEXT` / `MATCH ... AGAINST` (n-gram) 検索を、**公開エントリ全件を配信してブラウザ側で絞り込む**方式に置き換えました (public 側)。

- **`GET /search-index.json`**: 公開エントリ全件 (`path` / `title` / `body` 全文 / `published_at` / `image_url`) を JSON 配信。`visibility='public'` のみ
- **`public/static/search.js`**: `/search-index.json` を fetch し、軽いスコアリングで検索 (スペース区切り AND + title ヒット加点、大小無視)。debounce 200ms、結果は DOM 生成 (textContent で XSS 対策)
- **`search.html`**: SSR 検索結果を撤去し、検索フォーム + 結果コンテナ + `search.js` 読込の静的シェルに
- **サーバ**: `RenderSearchPage` から MATCH 検索を撤去。`FullTextSearchEntries` クエリ削除、`ListAllPublicEntries` 追加 (sqlc 再生成)
- biome の対象に `search.js` を追加 (Makefile)

トップページ/RSS が使う `SearchEntries` は変更なし。スキーマの `FULLTEXT KEY` 削除は次フェーズ。

## 検証 (docker 単体 mariadb + go run で確認)

この環境に docker-compose / ブラウザが無いため、mariadb を docker 単体起動 + ダミーデータ (public 7 / private 1) で API レベルを確認:

- ✅ `/search-index.json` は **public 7件のみ**返す
- ✅ private エントリ (`private-draft`) は index に**含まれない** (漏洩なし)
- ✅ 配信 1件に body 全文 (791B) と全フィールドが入る
- ✅ `/static/search.js` 配信 200 `text/javascript`
- ✅ `/search` シェルに `id="search-results"` と `/static/search.js` あり
- ✅ `go test ./internal/public/...`、`go build ./...`、`make biome-fix` 通過

⚠ **ブラウザ上の JS インタラクション (実際のインクリメンタル検索) は未確認** — 環境にブラウザが無いため。ロジックはレビューで担保。

## Test plan

- [ ] ブラウザで `/search` を開き、インクリメンタル検索 (AND / title 優先) が効くこと
- [ ] `?q=...` の初期検索が走ること
- [ ] private エントリが検索に出ないこと
- [ ] 大量エントリ時の初回ロード時間 (gzip サイズ)