### PR TITLE
chore(schema): drop FULLTEXT index and ENGINE clause for TiDB compatibility

### DIFF
--- a/db/init/01-schema.sql
+++ b/db/init/01-schema.sql
@@ -14,10 +14,8 @@ CREATE TABLE entry
     KEY created_at (created_at),
     KEY updated_at (updated_at),
     KEY published_at (published_at),
-    KEY last_edited_at (last_edited_at),
-    FULLTEXT KEY idx_bigram (title, body)
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4;
+    KEY last_edited_at (last_edited_at)
+) DEFAULT CHARSET = utf8mb4;
 
 create table entry_image
 (
@@ -27,8 +25,7 @@ create table entry_image
     PRIMARY KEY (path),
     KEY created_at (created_at),
     FOREIGN KEY (path) REFERENCES entry (path) ON DELETE CASCADE
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4;
+) DEFAULT CHARSET = utf8mb4;
 
 create table entry_link
 (
@@ -37,8 +34,7 @@ create table entry_link
     PRIMARY KEY (src_path, dst_title),
     FOREIGN KEY (src_path) REFERENCES entry (path) ON DELETE CASCADE,
     INDEX (dst_title)
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4;
+) DEFAULT CHARSET = utf8mb4;
 
 create table amazon_cache
 (
@@ -48,8 +44,7 @@ create table amazon_cache
     link             varchar(5000) not null,
     created_at       datetime      DEFAULT CURRENT_TIMESTAMP,
     KEY created_at (created_at)
-) engine = innodb
-  default charset = utf8mb4;
+) default charset = utf8mb4;
 
 CREATE TABLE admin_session
 (
@@ -59,4 +54,4 @@ CREATE TABLE admin_session
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     last_accessed_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY idx_expires_at (expires_at)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary

- `entry` テーブルの `FULLTEXT KEY idx_bigram (title, body)` を削除
- 全テーブルから `ENGINE=InnoDB` 句を削除 (`DEFAULT CHARSET=utf8mb4` は維持)

`MATCH ... AGAINST` を使う Go クエリは #857 (public) / #858 (admin) で既に撤去済み。インデックスはもう使われていないので落としても影響なし。これで同じ schema を MariaDB / TiDB CR 両方に投入できるようになる (TiDB は FULLTEXT 非対応、ストレージエンジン1種)。

[migration-plan.md](https://github.com/tokuhirom/blog4/blob/main/architecture/migration-plan.md) フェーズ1-2 の作業。

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (全パッケージ pass)
- [x] ローカル MariaDB 10.11 で `01-schema.sql` 投入 → SHOW INDEX で `idx_bigram` が無いこと確認
- [x] 続けて `02-dummy-data.sql` 投入 → 8 件登録できることを確認
- [ ] CI (biome / lint-and-test / docker-build / check-generated-files) グリーン

## Notes

- 本番 (EDB MariaDB) には何も変更を投げない。これは init script のみ。TiDB CR を Terraform で立てたあとに、この schema を新規 DB に投入する流れ。
- 旧 DB → 新 DB へのデータ移行 (FULLTEXT インデックス除外のリストア) は別 PR で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)