### PR TITLE
feat(terraform): scaffold terraform/ with TiDB CR resource

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26.3"
 node = "25"
+terraform = "1.14.3"
 "aqua:golangci/golangci-lint" = "2.12.2"
 "aqua:go-task/task" = "3.51.1"
 "github:sqlc-dev/sqlc" = "1.31.1"

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,12 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+*.tfvars
+*.tfvars.json
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/sacloud/sakura" {
+  version     = "3.12.0"
+  constraints = "~> 3.12"
+  hashes = [
+    "h1:ReIAM4U1iLbFd5k3foMj90E0+gDYPvlZ1wvt7S2ceC0=",
+    "zh:0570baee5d5e98eb6d4a183fbe370a2a82bdf652db575f2f5563c84a63c26ab2",
+    "zh:061476662cd35db0f6f30c5155c4c4feb2f8faae8f9d25d8b415b6c7ef419772",
+    "zh:083e0ccf7b4be57fe5bb053fc2a9db2ab721e217611f42a76c5594f2f17575c0",
+    "zh:35d3cc4c84c6dee9a56e1b76b5a32eb5970b2c5b0a83a7fcc8132eddd377df18",
+    "zh:3d0a940dd09b09778a5f047f78becbda6ee0367c4b4121f354c9c7893e53fe39",
+    "zh:4a09e5cf30ca26dc68d811967322b628df097b2001425b53e6d3b09b94db8638",
+    "zh:73013e73368f62a18fc953c9a4f05ee792e0cef70d2ab8d9306823b901580bea",
+    "zh:877a0343f0127c920d7e90f9a849f8af45e321b89a833e4a475169a8007b7bc6",
+    "zh:979882acec5f2619d0d097ebeb5d1aeec04b0c0f18a495c48c84b4535fec8090",
+    "zh:cf632ede8f03e763fc96ae729957bae1781ce1939142a2b8e30a62f8b6f2cd0e",
+    "zh:e85967bf1027ab0310f916dd32cb87acc81ecf28dae669ecbfc3e1e4b52cf258",
+    "zh:fece7ad48c71d9c18410e8da2a92dde3ffb45ee903ff67aa0f31840e884e495b",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,54 @@
+# blog4 Terraform
+
+`sacloud/sakura` provider (v3) で blog4 のインフラを管理する。
+
+## 設計方針
+
+- Provider: `sacloud/sakura` v3 に統一 (TiDB / AppRun 共用 / Container Registry / WebAccel / Object Storage が全部1プロバイダで揃う)
+- 認証: 環境変数 (`SAKURACLOUD_ACCESS_TOKEN` / `SAKURACLOUD_ACCESS_TOKEN_SECRET`)。アクセストークンはレポジトリにストアしない
+- パスワード等の機微情報: `password_wo` (write-only argument, Terraform 1.11+) と `TF_VAR_*` 環境変数で渡す。state に平文では入らない
+- tfstate: 現状はローカル。後続 PR で Object Storage backend に切り替える予定
+- 移行方針の全体像: [../architecture/migration-plan.md](../architecture/migration-plan.md)
+
+## このディレクトリで定義しているリソース
+
+| ファイル | リソース |
+|---|---|
+| `versions.tf` | terraform / provider 版固定 |
+| `provider.tf` | `sakura` provider 設定 |
+| `variables.tf` | 入力変数 |
+| `tidb.tf` | `sakura_ondemand_db` — TiDB CR インスタンス |
+| `outputs.tf` | hostname など |
+
+WebAccel / AppRun 共用 / Container Registry / Object Storage は後続 PR で追加 (既存リソースを import)。
+
+## 使い方
+
+### 1. mise で Terraform を入れる
+
+```bash
+mise install   # .mise.toml の terraform = "1.14.3" を入れる
+```
+
+### 2. 認証情報を環境変数で渡す
+
+```bash
+export SAKURACLOUD_ACCESS_TOKEN='...'
+export SAKURACLOUD_ACCESS_TOKEN_SECRET='...'
+export TF_VAR_tidb_password='...'   # 16文字以上推奨
+```
+
+### 3. init / plan / apply
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform output tidb_hostname` で接続先 (FQDN) が取れる。ポートは TiDB 固定の **4000**。
+
+### パスワードのローテート
+
+`var.tidb_password_version` を `1` → `2` に上げて、`TF_VAR_tidb_password` に新パスワードを入れて `apply`。リソース再作成なしで反映される。

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "tidb_hostname" {
+  description = "Hostname to connect to the TiDB CR instance (port 4000)."
+  value       = sakura_ondemand_db.blog4.hostname
+}
+
+output "tidb_database_name" {
+  description = "Database name created on the TiDB CR instance."
+  value       = sakura_ondemand_db.blog4.database_name
+}
+
+output "tidb_max_connections" {
+  description = "Max connections allowed by the TiDB CR instance."
+  value       = sakura_ondemand_db.blog4.max_connections
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,7 @@
+provider "sakura" {
+  # Authentication is supplied via environment variables:
+  #   SAKURACLOUD_ACCESS_TOKEN
+  #   SAKURACLOUD_ACCESS_TOKEN_SECRET
+  # Zone defaults to "is1a" — TiDB CR is offered in is1 only.
+  zone = var.zone
+}

--- a/terraform/tidb.tf
+++ b/terraform/tidb.tf
@@ -1,0 +1,11 @@
+resource "sakura_ondemand_db" "blog4" {
+  name          = "blog4"
+  database_name = var.tidb_database_name
+  database_type = "tidb"
+  region        = "is1"
+  description   = "blog4 primary database (TiDB CR)"
+  tags          = ["blog4", "managed-by:terraform"]
+
+  password_wo         = var.tidb_password
+  password_wo_version = var.tidb_password_version
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "zone" {
+  description = "Default Sakura Cloud zone. TiDB CR is in is1, so default to is1a."
+  type        = string
+  default     = "is1a"
+}
+
+variable "tidb_database_name" {
+  description = "Database name to create on the TiDB CR instance."
+  type        = string
+  default     = "blog4"
+}
+
+variable "tidb_password" {
+  description = "Password for the TiDB CR root user. Inject via TF_VAR_tidb_password (write-only)."
+  type        = string
+  sensitive   = true
+}
+
+variable "tidb_password_version" {
+  description = "Bump this to rotate tidb_password without recreating the resource."
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.14"
+
+  required_providers {
+    sakura = {
+      source  = "sacloud/sakura"
+      version = "~> 3.12"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

[migration-plan.md](https://github.com/tokuhirom/blog4/blob/main/architecture/migration-plan.md) のフェーズ2 (IaC 化) の出発点。

- `terraform/` ディレクトリを切って `sacloud/sakura` v3 でブートストラップ
- 第一歩として **TiDB CR (`sakura_ondemand_db`)** を定義 (申込不要・Terraform で直接作成可)
- パスワードは write-only argument (`password_wo`, Terraform 1.11+) + `TF_VAR_tidb_password` env で state に平文を残さない

| 追加ファイル | 内容 |
|---|---|
| `.mise.toml` | terraform 1.14.3 を pin |
| `terraform/versions.tf` | terraform ~> 1.14, sakura ~> 3.12 |
| `terraform/provider.tf` | env-var 認証 (`SAKURACLOUD_ACCESS_TOKEN*`) |
| `terraform/variables.tf` | zone, tidb_database_name, tidb_password (sensitive), tidb_password_version |
| `terraform/tidb.tf` | `sakura_ondemand_db` (database_type=tidb, region=is1) |
| `terraform/outputs.tf` | hostname / database_name / max_connections |
| `terraform/.gitignore` | state, .terraform/, tfvars 除外 |
| `terraform/.terraform.lock.hcl` | provider 再現性のため commit |
| `terraform/README.md` | 使い方・認証・パスワードローテ手順 |

## 含まれていないもの (後続 PR)

- WebAccel / AppRun 共用 / Container Registry / Object Storage の import
- tfstate の Object Storage backend 切替
- TiDB への schema 投入・データ移行

## Test plan

- [x] `terraform init -backend=false`
- [x] `terraform validate` → Success
- [x] `terraform fmt -check -diff` → 差分なし
- [ ] (ユーザー作業) `terraform plan` / `apply` で TiDB インスタンスが立ち上がること
- [ ] (ユーザー作業) `terraform output tidb_hostname` で接続先取得・mysql クライアントで接続確認

## Notes

- tfstate はとりあえずローカル。コミット対象から除外済み (`*.tfstate*`)。Object Storage backend への移行は別 PR で
- `allowed_networks` は未指定 (= 全許可)。AppRun 共用は NAT pool なので IP 制限は現実的でなく、TLS + パスワードで守る方針
- パスワードローテートは `var.tidb_password_version` を ++ するだけでリソース再作成なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)