### PR TITLE
feat(terraform): tfstate を Object Storage backend へ

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,7 @@
 go = "1.26.4"
 node = "25"
 terraform = "1.14.3"
+awscli = "2.34.64"
 "aqua:golangci/golangci-lint" = "2.12.2"
 "aqua:go-task/task" = "3.51.1"
 "github:sqlc-dev/sqlc" = "1.31.1"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,7 +7,7 @@
 - Provider: `sacloud/sakura` v3 に統一 (TiDB / AppRun 共用 / Container Registry / WebAccel / Object Storage が全部1プロバイダで揃う)
 - 認証: 環境変数 (`SAKURACLOUD_ACCESS_TOKEN` / `SAKURACLOUD_ACCESS_TOKEN_SECRET`)。アクセストークンはレポジトリにストアしない
 - パスワード等の機微情報: `password_wo` (write-only argument, Terraform 1.11+) と `TF_VAR_*` 環境変数で渡す。state に平文では入らない
-- tfstate: 現状はローカル。後続 PR で Object Storage backend に切り替える予定
+- tfstate: さくらのオブジェクトストレージ (S3 互換) backend。`backend.tf` 参照。state ロックは S3 ネイティブの `use_lockfile`
 - 移行方針の全体像: [../architecture/migration-plan.md](../architecture/migration-plan.md)
 
 ## このディレクトリで定義しているリソース
@@ -15,6 +15,7 @@
 | ファイル | リソース |
 |---|---|
 | `versions.tf` | terraform / provider 版固定 |
+| `backend.tf` | tfstate の Object Storage (S3 互換) backend |
 | `provider.tf` | `sakura` provider 設定 |
 | `variables.tf` | 入力変数 |
 | `tidb.tf` | `sakura_ondemand_db` — TiDB CR インスタンス |
@@ -33,19 +34,47 @@ mise install   # .mise.toml の terraform = "1.14.3" を入れる
 ### 2. 認証情報を環境変数で渡す
 
 ```bash
+# さくらのクラウド API (provider 用)
 export SAKURACLOUD_ACCESS_TOKEN='...'
 export SAKURACLOUD_ACCESS_TOKEN_SECRET='...'
 export TF_VAR_tidb_password='...'   # 16文字以上推奨
+
+# オブジェクトストレージの S3 アクセスキー (backend 用)
+export AWS_ACCESS_KEY_ID='...'
+export AWS_SECRET_ACCESS_KEY='...'
 ```
 
-### 3. init / plan / apply
+### 3. state バケットの用意 (初回のみ・済)
+
+`backend.tf` が使う state バケット `blog4-tfstate` は鶏卵問題のため
+Terraform 管理外。**さくらのクラウド コントロールパネルから private バケットとして作成済み**。
+作り直す場合もコンパネから一度だけ手動で作る。
+
+state 破損時の巻き戻し用に **versioning を有効化済み**。これはコンパネでは
+設定できないため S3 互換 CLI で行う:
+
+```bash
+aws --endpoint-url=https://s3.isk01.sakurastorage.jp --region jp-north-1 \
+    s3api put-bucket-versioning --bucket blog4-tfstate \
+    --versioning-configuration Status=Enabled
+```
+
+### 4. init / plan / apply
 
 ```bash
 cd terraform
-terraform init
+terraform init                 # 新規。backend は最初から Object Storage
 terraform plan
 terraform apply
 ```
+
+ローカル tfstate から移行する場合は init 時に state コピーを促される:
+
+```bash
+terraform init -migrate-state   # 既存 local state を Object Storage へコピー
+```
+
+移行が済んだらローカルの `terraform.tfstate*` は削除してよい。
 
 `terraform output tidb_hostname` で接続先 (FQDN) が取れる。ポートは TiDB 固定の **4000**。
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,32 @@
+# tfstate を さくらのオブジェクトストレージ (S3 互換) に置く。
+#
+# - backend ブロックは変数を使えないため、静的値のみ。
+#   認証情報 (S3 アクセスキー) は環境変数で渡す:
+#     AWS_ACCESS_KEY_ID     = <Object Storage のアクセスキー>
+#     AWS_SECRET_ACCESS_KEY = <同シークレット>
+# - AWS ではないので各種 skip フラグと path-style が必要。
+# - state ロックは S3 ネイティブのロックファイル (use_lockfile, TF 1.10+)。
+#   DynamoDB 相当は不要。
+# - state バケット (blog4-tfstate) は鶏卵問題のため Terraform 管理外。
+#   コンパネで private バケットを作り、versioning を有効化しておく。README 参照。
+terraform {
+  backend "s3" {
+    bucket = "blog4-tfstate"
+    key    = "blog4/terraform.tfstate"
+    region = "jp-north-1"
+
+    endpoints = {
+      s3 = "https://s3.isk01.sakurastorage.jp"
+    }
+
+    use_path_style = true
+    use_lockfile   = true
+
+    # 非 AWS S3 互換ストレージ向け: AWS 固有の検証/メタAPIを呼ばせない
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_s3_checksum            = true
+  }
+}


### PR DESCRIPTION
## 概要

Terraform の tfstate をローカルから さくらのオブジェクトストレージ (S3 互換) backend へ移行する。AppRun import など秘密情報が state に乗るリソースを管理する前提として、先に state 置き場を整える。

## 変更点

- `terraform/backend.tf` (新規) — `backend "s3"` をさくら Object Storage 向けに設定
  - path-style + 非 AWS 向け skip フラグ群
  - state ロックは S3 ネイティブの `use_lockfile` (DynamoDB 不要)
- `terraform/README.md` — backend 用 env、state バケットの素性、`terraform init -migrate-state` の手順
- `.mise.toml` — `awscli` を追加 (versioning 有効化などコンパネ非対応の操作用)

## state バケットについて (Terraform 管理外)

鶏卵問題のため `blog4-tfstate` は IaC 管理外。手動で用意済み:

- さくらのクラウド コントロールパネルから private バケット作成
- 巻き戻し用に versioning を aws cli で有効化 (コンパネ非対応のため)

## 移行手順 (マージ後に手元で実施)

```bash
cd terraform
export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
terraform init -migrate-state
```

## 次の作業

このあと AppRun 共用型を import (image / traffics は `ignore_changes`、env secret は `var.*` 化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)