### PR TITLE
feat(terraform): AppRun 共用型アプリを import

### DIFF
--- a/terraform/.env
+++ b/terraform/.env
@@ -25,3 +25,24 @@ TF_VAR_tidb_password="op://blog4/blog4-tidb/root-password"
 TF_VAR_tidb_password_version=1
 TF_VAR_tidb_database_name=blog5
 
+# --- AppRun env (実値は 1Password 由来。import を no-op にするなら現本番値を入れる) ---
+# 参照先アイテム (blog4 vault に作る):
+#   blog4-admin       : user, pw
+#   blog4-app-db      : host, port, name, user, password
+#   blog4-amazon-paapi: access-key, secret-key
+#   blog4-s3-app      : access-key-id, secret-access-key
+#   blog4-webaccel    : guard
+TF_VAR_admin_user="op://blog4/blog4-admin/user"
+TF_VAR_admin_pw="op://blog4/blog4-admin/pw"
+TF_VAR_amazon_paapi5_access_key="op://blog4/blog4-amazon-paapi/access-key"
+TF_VAR_amazon_paapi5_secret_key="op://blog4/blog4-amazon-paapi/secret-key"
+TF_VAR_database_host="op://blog4/blog4-app-db/host"
+TF_VAR_database_name="op://blog4/blog4-app-db/name"
+TF_VAR_database_password="op://blog4/blog4-app-db/password"
+TF_VAR_database_port="op://blog4/blog4-app-db/port"
+TF_VAR_database_user="op://blog4/blog4-app-db/user"
+TF_VAR_s3_access_key_id="op://blog4/blog4-s3-app/access-key-id"
+TF_VAR_s3_secret_access_key="op://blog4/blog4-s3-app/secret-access-key"
+TF_VAR_webaccel_guard="op://blog4/blog4-webaccel/guard"
+TF_VAR_gin_mode=release
+

--- a/terraform/apprun.tf
+++ b/terraform/apprun.tf
@@ -1,0 +1,60 @@
+# 既存 AppRun 共用型アプリ (blog.64p.org の origin)。
+#
+# env の値は AppRun API が読み返さない (常に null/sensitive で返る) ため、
+# Terraform 側からは drift 検知できない。値の正本は 1Password (blog4 vault)
+# に置き、ここでは var 経由で push する (= ゼロからの再構築を可能にする DR 用途)。
+#
+# image は CI (.github/actions/deploy-apprun/deploy.sh) が毎デプロイで PATCH
+# するため lifecycle.ignore_changes で管理外にする。traffics も CI 側。
+locals {
+  # AppRun に流し込む環境変数。実値は 1Password 由来 (TF_VAR_* / op run)。
+  apprun_env = {
+    ADMIN_USER               = var.admin_user
+    ADMIN_PW                 = var.admin_pw
+    AMAZON_PAAPI5_ACCESS_KEY = var.amazon_paapi5_access_key
+    AMAZON_PAAPI5_SECRET_KEY = var.amazon_paapi5_secret_key
+    DATABASE_HOST            = var.database_host
+    DATABASE_NAME            = var.database_name
+    DATABASE_PASSWORD        = var.database_password
+    DATABASE_PORT            = var.database_port
+    DATABASE_USER            = var.database_user
+    GIN_MODE                 = var.gin_mode
+    S3_ACCESS_KEY_ID         = var.s3_access_key_id
+    S3_SECRET_ACCESS_KEY     = var.s3_secret_access_key
+    WEBACCEL_GUARD           = var.webaccel_guard
+  }
+}
+
+resource "sakura_apprun_shared" "blog4" {
+  name            = "blog4"
+  port            = 8181
+  timeout_seconds = 60
+  min_scale       = 1
+  max_scale       = 1
+
+  components = [
+    {
+      # CI は image しか PATCH しないため component name は安定 (タグ込みだが固定)。
+      name       = "blog4:75e6b60"
+      max_cpu    = "0.5"
+      max_memory = "1Gi"
+
+      deploy_source = {
+        container_registry = {
+          image    = "tokuhirom-private.sakuracr.jp/blog4:75e6b60"
+          server   = "tokuhirom-private.sakuracr.jp"
+          username = "pull"
+        }
+      }
+
+      env = [for k, v in local.apprun_env : { key = k, value = v }]
+    },
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      components[0].deploy_source.container_registry.image,
+      traffics,
+    ]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,3 +12,8 @@ output "tidb_max_connections" {
   description = "Max connections allowed by the TiDB CR instance."
   value       = sakura_ondemand_db.blog4.max_connections
 }
+
+output "apprun_public_url" {
+  description = "AppRun アプリの公開 URL (WebAccel の origin)."
+  value       = sakura_apprun_shared.blog4.public_url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,79 @@ variable "tidb_password_version" {
   type        = number
   default     = 1
 }
+
+# --- AppRun 環境変数 (実値は 1Password 由来。TF_VAR_* で注入) ---
+# AppRun API は env 値を読み返さないため、ここに与えた値が apply 時に push される。
+# import 時の挙動を no-op にしたい場合は「現在の本番値」を 1Password に入れること。
+
+variable "admin_user" {
+  description = "AppRun env ADMIN_USER (管理 UI のユーザ名)."
+  type        = string
+}
+
+variable "admin_pw" {
+  description = "AppRun env ADMIN_PW (管理 UI のパスワード)."
+  type        = string
+  sensitive   = true
+}
+
+variable "amazon_paapi5_access_key" {
+  description = "AppRun env AMAZON_PAAPI5_ACCESS_KEY."
+  type        = string
+  sensitive   = true
+}
+
+variable "amazon_paapi5_secret_key" {
+  description = "AppRun env AMAZON_PAAPI5_SECRET_KEY."
+  type        = string
+  sensitive   = true
+}
+
+variable "database_host" {
+  description = "AppRun env DATABASE_HOST (接続先 DB ホスト)."
+  type        = string
+}
+
+variable "database_name" {
+  description = "AppRun env DATABASE_NAME."
+  type        = string
+}
+
+variable "database_password" {
+  description = "AppRun env DATABASE_PASSWORD."
+  type        = string
+  sensitive   = true
+}
+
+variable "database_port" {
+  description = "AppRun env DATABASE_PORT (env は文字列で渡す)."
+  type        = string
+}
+
+variable "database_user" {
+  description = "AppRun env DATABASE_USER."
+  type        = string
+}
+
+variable "gin_mode" {
+  description = "AppRun env GIN_MODE (release など)."
+  type        = string
+}
+
+variable "s3_access_key_id" {
+  description = "AppRun env S3_ACCESS_KEY_ID (アプリの S3 アクセスキー)."
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_secret_access_key" {
+  description = "AppRun env S3_SECRET_ACCESS_KEY."
+  type        = string
+  sensitive   = true
+}
+
+variable "webaccel_guard" {
+  description = "AppRun env WEBACCEL_GUARD (オリジン保護トークン)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## 概要

既存の AppRun 共用型アプリ (`blog.64p.org` の origin) を Terraform 管理下へ import 済み。`terraform apply` で取り込み完了を確認済み。

## 設計上のポイント

AppRun API は env の **値を読み返さない** (常に `null`/sensitive)。そのため Terraform では env の drift 検知ができない。これを承知のうえで:

- **env 値の正本は 1Password (`blog4` vault)**、Terraform は `var.*` 経由で push する。狙いは「ゼロから `apply` 一発で再構築できる」DR/再現性。
- **image** は CI (`.github/actions/deploy-apprun/deploy.sh`) が毎デプロイで PATCH するため、`traffics` と共に `lifecycle.ignore_changes` で管理外。
- shape (scale/port/cpu/memory/timeout/registry) は読み返せるので素直に管理。

## 変更点

- `terraform/apprun.tf` (新規) — `sakura_apprun_shared.blog4`。env は `local.apprun_env` (13個) を変数から流し込み
- `terraform/variables.tf` — AppRun env 用の13変数を追加 (secret は `sensitive`)
- `terraform/.env` — AppRun env の `op://` 参照を追記
- `terraform/outputs.tf` — `apprun_public_url`
- import ブロック (`imports.tf`) は取り込み完了につき削除

## 1Password (`blog4` vault) の item

| item | field |
|---|---|
| `blog4-admin` | `user` / `pw` |
| `blog4-app-db` | `host` / `port` / `name` / `user` / `password` |
| `blog4-amazon-paapi` | `access-key` / `secret-key` |
| `blog4-s3-app` | `access-key-id` / `secret-access-key` |
| `blog4-webaccel` | `guard` |

## 注意 / 既知の制約

- env 値の正本は 1Password。コンパネで env を直接変えると Terraform から見えない (次の apply で 1Password の値に上書きされる)。env 変更は 1Password 経由に統一する。
- TiDB 移行 (フェーズ3) では `blog4-app-db` を TiDB の値に変えて再 apply することでカットオーバーする。

## 次の作業

Container Registry / WebAccel / Object Storage バケットの import。

🤖 Generated with [Claude Code](https://claude.com/claude-code)