### PR TITLE
feat(terraform): WebAccel サイト 2 つ (blog.64p.org / blog-attachments.64p.org) を import

### DIFF
--- a/terraform/webaccel.tf
+++ b/terraform/webaccel.tf
@@ -19,28 +19,36 @@ resource "sakura_webaccel" "blog4" {
 
 # WebAccel サイト (blog-attachments.64p.org → Object Storage の blog3-attachments バケット)。
 #
-# !!! 現状 import 不可 (provider 制約) のためコンパネ運用のまま。!!!
-# sacloud/sakura v3.12 の sakura_webaccel は、バケット origin のサイトを import する際の
-# Read で write-only の access_key_wo を受け取れず "origin_parameters must be provided to
-# keep bucket credentials" で必ず失敗する (credentials_wo_version でも回避不可)。
-# provider 側が対応したら、下記の確認済み設定で取り込む (値はコンパネと一致確認済み):
+# sacloud/sakura v3.12.0 ではバケット origin のサイトを import できず
+# ("origin_parameters must be provided to keep bucket credentials")、コンパネ運用のまま
+# 保留していたが、v3.12.2 の "fix(webaccel): support import for webaccel bucket origin"
+# で解消したので取り込む。
 #
-#   resource "sakura_webaccel" "attachments" {
-#     name              = "blog3-attachments"
-#     domain_type       = "own_domain"
-#     domain            = "blog-attachments.64p.org"
-#     request_protocol  = "https"
-#     normalize_ae      = "gzip"
-#     default_cache_ttl = 3600
-#     vary_support      = false
-#     origin_parameters = {
-#       type                   = "bucket"
-#       bucket_name            = "blog3-attachments"
-#       endpoint               = "s3.isk01.sakurastorage.jp"
-#       region                 = "jp-north-1"
-#       use_document_index     = false
-#       access_key_wo          = var.webaccel_attachments_access_key      # 1Password
-#       secret_access_key_wo   = var.webaccel_attachments_secret_access_key
-#       credentials_wo_version = 1
-#     }
-#   }
+# バケットの認証情報 (access_key_wo / secret_access_key_wo) はここに書かない。
+# write-only 属性なので Terraform は既存値を読まず、書かなければ送りもしない
+# = コンパネで設定済みの認証情報がそのまま維持される。
+# use_document_index も書かない (書くと値の追加で in-place update が発生する)。
+# 差分ゼロで import できることは plan で確認済み。
+resource "sakura_webaccel" "attachments" {
+  name              = "blog3-attachments"
+  domain_type       = "own_domain"
+  domain            = "blog-attachments.64p.org"
+  request_protocol  = "https"
+  normalize_ae      = "gzip"
+  default_cache_ttl = 3600
+  vary_support      = false
+
+  origin_parameters = {
+    type        = "bucket"
+    bucket_name = "blog3-attachments"
+    endpoint    = "s3.isk01.sakurastorage.jp"
+    region      = "jp-north-1"
+  }
+}
+
+# 既存サイトを state に取り込む。apply で state に入ったあとは削除してよい
+# (残しても no-op なので、履歴として当面残す)。
+import {
+  to = sakura_webaccel.attachments
+  id = "113602500600"
+}

--- a/terraform/webaccel.tf
+++ b/terraform/webaccel.tf
@@ -1,0 +1,46 @@
+# WebAccel サイト (blog.64p.org の前段 CDN / TLS 終端)。
+# TLS は Let's Encrypt 自動運用のため証明書リソースは管理しない。
+resource "sakura_webaccel" "blog4" {
+  name              = "blog.64p.org"
+  domain_type       = "own_domain"
+  domain            = "blog.64p.org"
+  request_protocol  = "https-redirect"
+  normalize_ae      = "gzip"
+  default_cache_ttl = -1
+  vary_support      = false
+
+  origin_parameters = {
+    type     = "web"
+    protocol = "https"
+    # AppRun (sakura_apprun_shared.blog4) の ingress ホスト名。
+    origin = "app-bdc9ce86-732c-4b9f-9576-a4313eed0cbd.ingress.apprun.sakura.ne.jp"
+  }
+}
+
+# WebAccel サイト (blog-attachments.64p.org → Object Storage の blog3-attachments バケット)。
+#
+# !!! 現状 import 不可 (provider 制約) のためコンパネ運用のまま。!!!
+# sacloud/sakura v3.12 の sakura_webaccel は、バケット origin のサイトを import する際の
+# Read で write-only の access_key_wo を受け取れず "origin_parameters must be provided to
+# keep bucket credentials" で必ず失敗する (credentials_wo_version でも回避不可)。
+# provider 側が対応したら、下記の確認済み設定で取り込む (値はコンパネと一致確認済み):
+#
+#   resource "sakura_webaccel" "attachments" {
+#     name              = "blog3-attachments"
+#     domain_type       = "own_domain"
+#     domain            = "blog-attachments.64p.org"
+#     request_protocol  = "https"
+#     normalize_ae      = "gzip"
+#     default_cache_ttl = 3600
+#     vary_support      = false
+#     origin_parameters = {
+#       type                   = "bucket"
+#       bucket_name            = "blog3-attachments"
+#       endpoint               = "s3.isk01.sakurastorage.jp"
+#       region                 = "jp-north-1"
+#       use_document_index     = false
+#       access_key_wo          = var.webaccel_attachments_access_key      # 1Password
+#       secret_access_key_wo   = var.webaccel_attachments_secret_access_key
+#       credentials_wo_version = 1
+#     }
+#   }


### PR DESCRIPTION
## 概要

`blog.64p.org` の WebAccel サイト(前段 CDN / TLS 終端、AppRun が origin)を Terraform 管理下へ import 済み。`terraform apply` で **0 change** を確認済み。TLS は Let's Encrypt 自動更新のため証明書リソース (`sakura_webaccel_certificate`) は管理しない。

## 変更点

- `terraform/webaccel.tf` (新規)
  - `sakura_webaccel.blog4` — origin = AppRun ingress、`request_protocol = https-redirect`、`normalize_ae = gzip` ほか実値どおり
  - `blog-attachments.64p.org` は**コメントで確認済み設定を残す**(下記理由で現状 import 不可)

## blog-attachments.64p.org を入れていない理由 (provider 制約)

attachments サイトは origin が Object Storage バケット。`sacloud/sakura` v3.12 の `sakura_webaccel` は、バケット origin のサイトを **import する際の Read で write-only の `access_key_wo` を受け取れず**、`origin_parameters must be provided to keep bucket credentials` で必ず失敗する(`credentials_wo_version` でも回避不可)。data source の Read は通るが resource の Read が通らない、という provider の作りの問題。

- 設定値自体はコンパネと突き合わせて確認済み(`webaccel.tf` のコメント参照)なので、provider が対応次第すぐ有効化できる。
- それまでは attachments はコンパネ運用のまま。静的な画像配信 CDN で低リスク。

## import 手法メモ

サイト ID はコンパネに表記が無いため、`data "sakura_webaccel"` で domain から引いてその `id` を config-driven import に渡す方式で取り込んだ(import 完了後に data source / import ブロックは削除済み)。

## 次の作業

Container Registry / Object Storage バケットの import。

🤖 Generated with [Claude Code](https://claude.com/claude-code)