### PR TITLE
fix(deploy): show PATCH response body on error

### DIFF
--- a/.github/actions/deploy-apprun/deploy.sh
+++ b/.github/actions/deploy-apprun/deploy.sh
@@ -28,7 +28,9 @@ jq --arg image "$image" '
   | .components[0].deploy_source.container_registry.image = "\($image)"
 ' app.json > deploy.json
 
-curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" -X PATCH -d '@deploy.json' -o /dev/null \
+# PATCH が 400 等で失敗したときにレスポンスボディ(エラー原因)を確認できるよう、
+# --fail-with-body を使い、ボディは /dev/null に捨てずに標準出力へ出す
+curl --fail-with-body --no-progress-meter -u "$access_token_id:$access_token_secret" -X PATCH -d '@deploy.json' \
   "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/$apprun_app_id"
 
 curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" \


### PR DESCRIPTION
## 背景

さくら App Run へのデプロイ時、`deploy.sh` の PATCH リクエストが HTTP 400 で失敗していたが、原因が全く分からなかった。

```
curl -f --no-progress-meter -u ***:*** -X PATCH -d @deploy.json -o /dev/null ...
curl: (22) The requested URL returned error: 400
```

理由は2つ:
- `curl -f`(`--fail`)は 4xx/5xx のときレスポンスボディを出力しない
- さらに `-o /dev/null` でボディを捨てていた

このため、サーバーが返している 400 のエラーメッセージが完全に見えなくなっていた。

## 変更

PATCH の1行のみ変更:
- `-f` → `--fail-with-body`(失敗ステータスは維持しつつ、レスポンスボディは出力)
- `-o /dev/null` を削除

これで PATCH 失敗時にエラー本文を確認できる。

## 補足

- `--fail-with-body` は curl 7.76.0(2021-04)以降。GitHub Actions の ubuntu ランナーは対応済み。
- request payload(`deploy.json`)は secret を含むためログには出さない方針を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)