### PR TITLE
feat(deploy): push image to ghcr.io instead of sakura registry

### DIFF
--- a/.github/actions/deploy-apprun/deploy.sh
+++ b/.github/actions/deploy-apprun/deploy.sh
@@ -20,15 +20,19 @@ curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" -o 'app.j
   "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/$apprun_app_id"
 
 # app.json から deploy.json を生成
-# - container_registry.server と container_registry.username を削除(こうしないとエラーになる)
+# - container_registry.server を ghcr.io に設定
+# - public パッケージなので username / password は不要(削除する)
 # - all_traffic_available を true に設定
 jq --arg image "$image" '
-  del(.components[0].deploy_source.container_registry.server, .components[0].deploy_source.container_registry.username)
+  .components[0].deploy_source.container_registry.server = "ghcr.io"
+  | del(.components[0].deploy_source.container_registry.username, .components[0].deploy_source.container_registry.password)
   | .all_traffic_available = true
   | .components[0].deploy_source.container_registry.image = "\($image)"
 ' app.json > deploy.json
 
-curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" -X PATCH -d '@deploy.json' -o /dev/null \
+# PATCH が 400 等で失敗したときにレスポンスボディ(エラー原因)を確認できるよう、
+# --fail-with-body を使い、ボディは /dev/null に捨てずに標準出力へ出す
+curl --fail-with-body --no-progress-meter -u "$access_token_id:$access_token_secret" -X PATCH -d '@deploy.json' \
   "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/$apprun_app_id"
 
 curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" \

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -19,9 +23,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
-          registry: ${{ vars.SAKURA_REGISTRY_DOMAIN }}
-          username: ${{ vars.SAKURA_REGISTRY_USERNAME }}
-          password: ${{ secrets.SAKURA_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract GIT_HASH
         id: vars
@@ -32,7 +36,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ vars.SAKURA_REGISTRY_DOMAIN }}/blog4:${{ env.GIT_HASH }}
+          tags: ghcr.io/${{ github.repository_owner }}/blog4:${{ env.GIT_HASH }}
           build-args: |
             GIT_HASH=${{ env.GIT_HASH }}
 
@@ -42,4 +46,4 @@ jobs:
           token_id: ${{ secrets.SACLOUD_API_TOKEN_ID }}
           token_secret: ${{ secrets.SAKURA_API_TOKEN_SECRET }}
           app_id: ${{ vars.APPRUN_APP_ID }}
-          image: ${{ vars.SAKURA_REGISTRY_DOMAIN }}/blog4:${{ env.GIT_HASH }}
+          image: ghcr.io/${{ github.repository_owner }}/blog4:${{ env.GIT_HASH }}


### PR DESCRIPTION
## 概要

AppRun 共用型が ghcr.io に対応したため、コンテナイメージの push 先をさくらの private registry (`tokuhirom-private.sakuracr.jp`) から **ghcr.io** へ移行する。

パッケージを **public** にすることで AppRun は認証なしで pull でき、レジストリ資格情報の同期に起因する `image authorization failed`(直近のデプロイ失敗の原因)を根本的に解消する。

## 変更

- **publish-image.yml**
  - login/push 先を `ghcr.io` に変更(`username: github.actor` / `password: GITHUB_TOKEN`)
  - `permissions: packages: write` を付与
  - image を `ghcr.io/${{ github.repository_owner }}/blog4:${GIT_HASH}` に
- **deploy.sh**
  - `container_registry.server` を `ghcr.io` に設定、`username`/`password` を除去(public のため不要)
  - PATCH 失敗時にレスポンスボディを見られるよう `--fail-with-body` に変更(`-o /dev/null` 廃止)

## マージ後に必要な手動作業 ⚠️

1. **初回 push でパッケージが作られるが、ghcr のデフォルトは private**。そのままだと AppRun が認証なしで pull できずデプロイが失敗する。
2. 初回 push 後、GitHub のパッケージ設定で `blog4` パッケージを **public** に変更する(Package settings → Change visibility → Public)。
3. その後のデプロイで pull が通るようになる。
4. AppRun 側は現在さくら registry 設定なので、`server` を ghcr.io に切り替える初回 PATCH が通るか要確認(失敗しても `--fail-with-body` でエラー本文が見える)。

## 補足

- 従来使っていた `SAKURA_REGISTRY_*`(vars/secret)はこのフローでは不要になる。他で参照が無ければ後片付け可能。
- `SACLOUD_API_TOKEN_ID` / `SAKURA_API_TOKEN_SECRET`(AppRun 管理 API 用)は引き続き必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)