### PR TITLE
feat(scripts): add DB count/dump/restore scripts and migration runbook

### DIFF
--- a/architecture/migration-plan.md
+++ b/architecture/migration-plan.md
@@ -113,6 +113,10 @@ DB 移行の前提。複数 PR に分ける。
 5. `terraform plan` で既存リソースとの差分を確認しながら import を進める
 
 ### フェーズ 3: データ移行 & カットオーバー
+
+実作業の手順とコマンドは [migration-runbook.md](./migration-runbook.md) に切り出した
+(`scripts/db-count.sh` / `db-dump.sh` / `db-restore.sh` を使う)。
+
 6. MariaDB から論理ダンプ (`mysqldump --no-tablespaces` 等) を取得
 7. TiDB へリストア (FULLTEXT 行は schema から除外済みのものを使う)
 8. ステージング的に新 DB を指す AppRun バージョンを用意し検証

--- a/architecture/migration-runbook.md
+++ b/architecture/migration-runbook.md
@@ -1,0 +1,175 @@
+# blog4 DB 移行 runbook (EDB MariaDB → TiDB CR)
+
+[migration-plan.md](./migration-plan.md) のフェーズ3 (データ移行 & カットオーバー) の実作業手順。
+想定する流れは **両方カウント → 両方バックアップ → MariaDB から TiDB へ移す → 両方カウント**。
+
+## 使うスクリプト
+
+| スクリプト | 役割 |
+|---|---|
+| `scripts/db-count.sh [tidb\|mariadb\|both]` | テーブルごとの件数 (記事数、公開/非公開の内訳) を表示。`both` は差分に `*` を付けて並べる |
+| `scripts/db-dump.sh [options] [tidb\|mariadb\|both]` | mysqldump して `/tmp` に置く |
+| `scripts/db-restore.sh [--target tidb\|mariadb] <file>` | SQL ファイルを流し込む |
+
+共通事項:
+
+- **必ず `op run --env-file=terraform/.env --` 経由で実行する。** 接続情報は 1Password が正本
+  (TiDB = `blog4-tidb`、MariaDB = `blog4-app-db`)
+- mysql クライアントはローカルに入れず docker で動かす (TiDB へは `mysql:8.4`、
+  旧 EDB へは `mariadb:10.11.18` のクライアント)
+- パスワードは 600 の一時ファイル経由でクライアントに渡す。`ps` や `docker inspect` には出ない
+- TiDB のホスト名は `terraform output tidb_hostname` から取る。terraform を通したくないときは
+  `TIDB_HOST=... TIDB_USER=...` を環境変数で明示すれば terraform なしで動く
+
+TiDB のユーザ名は **データベース名と同じ** (`blog5`) と仮定している。認証エラーになる場合は
+`TIDB_USER=...` で上書きし、判明した正しい値をこの文書に反映すること。
+
+## 移行前に片付ける必要があるアプリ側の課題
+
+データを移す前に、以下が未解決だとカットオーバーで確実に失敗する。
+
+1. **アプリが TLS で DB に接続できない** — `cmd/blog4/main.go:35` の `mysql.Config` に
+   `TLSConfig` が無い。TiDB CR は TLS 必須なので `TLSConfig: "true"` 相当が要る。
+2. **DB 名の環境変数名が terraform とアプリでずれている** — `terraform/apprun.tf:17` は
+   `DATABASE_NAME` を送るが、アプリが読むのは `DATABASE_DB` (`internal/config.go:16`、
+   デフォルト `blog3`)。このままだと TiDB の `blog5` ではなく `blog3` に繋ぎにいく。
+3. **アプリ内の日次バックアップが `mariadb-dump`** — `internal/backup.go:43`。TiDB 相手に
+   動くか確認が要る (認証プラグインと TLS)。動かないなら `mysqldump` に替える。
+4. **FOREIGN KEY の対応状況** — `db/init/01-schema.sql` は `entry_image` / `entry_link` に
+   FK を張っている。TiDB の FK は v8.5 で GA。手順4 (スキーマ作成) が通れば対応済みと判断でき、
+   落ちるならスキーマから FK を外し、削除時の CASCADE をアプリ側で持つ。
+
+## 手順
+
+以降のコマンドはリポジトリルートで実行する。
+
+### 0. 疎通確認
+
+```bash
+op signin
+op run --env-file=terraform/.env -- ./scripts/db-count.sh mariadb
+op run --env-file=terraform/.env -- ./scripts/db-count.sh tidb
+```
+
+TiDB 側は移行前なので「テーブルが1つもない」と出るのが正常。ここで認証エラーが出るなら
+ユーザ名/パスワードの仮定を見直す (上記の `TIDB_USER` 注記を参照)。
+
+### 1. 移行前のカウントを記録する
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-count.sh both | tee /tmp/blog4-count-before.txt
+```
+
+この出力が移行の正解値になる。手順6 で突き合わせる。
+
+### 2. MariaDB のバックアップを取る
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-dump.sh --gzip mariadb
+# -> /tmp/blog4-mariadb-<timestamp>.sql.gz (スキーマ + データのフルダンプ)
+```
+
+これは**切り戻し用の保険**。移行に使うダンプ (手順5) とは別物なので、消さずに取っておく。
+
+### 3. TiDB のバックアップを取る
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-dump.sh --gzip tidb
+```
+
+初回は空だが、やり直し (2回目以降の移行) では TiDB 側に中途半端なデータが入った状態で
+再実行することになるので、毎回取る。
+
+### 4. TiDB にスキーマを作る
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-restore.sh db/init/01-schema.sql
+```
+
+**本番 MariaDB のスキーマをそのままコピーしない。** 本番のテーブルには `FULLTEXT KEY idx_bigram`
+が残っている可能性があり、TiDB では作れない。`db/init/01-schema.sql` (FULLTEXT 削除済み) を正とする。
+
+やり直すときは先に既存テーブルを消す (FK があるので子テーブルから):
+
+```bash
+cat >/tmp/blog4-drop.sql <<'SQL'
+DROP TABLE IF EXISTS entry_link, entry_image, admin_session, amazon_cache, entry;
+SQL
+op run --env-file=terraform/.env -- ./scripts/db-restore.sh --yes /tmp/blog4-drop.sql
+```
+
+### 5. MariaDB から TiDB へデータを移す
+
+```bash
+# データのみダンプ (CREATE TABLE を含めない。セッションは移さない)
+DUMP=$(op run --env-file=terraform/.env -- ./scripts/db-dump.sh --data-only --exclude-sessions mariadb | tail -1)
+echo "$DUMP"
+
+# TiDB へ流し込む
+op run --env-file=terraform/.env -- ./scripts/db-restore.sh "$DUMP"
+```
+
+`admin_session` を除外しているので、カットオーバー後は管理画面に再ログインが必要になる。
+
+### 6. カウントを照合する
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-count.sh both
+```
+
+`diff` 列の `*` が `admin_session` だけになっていれば成功
+(セッションは意図的に移していないため差が出る)。`entry` / `entry:public` / `entry_image` /
+`entry_link` / `amazon_cache` が一致していることを手順1の出力と突き合わせて確認する。
+
+### 7. カットオーバー
+
+1. 移行中に記事を書かない (書いたら手順5をやり直す)。確実にやるなら AppRun を止めるか、
+   管理画面を触らない時間帯を選ぶ
+2. 1Password の `blog4-app-db` を TiDB の値に更新する:
+
+   | field | 新しい値 |
+   |---|---|
+   | `host` | `terraform output tidb_hostname` の値 (`blog5.tidb-is1.db.sakurausercontent.com`) |
+   | `port` | `4000` |
+   | `name` | `blog5` |
+   | `user` | `blog5` (= データベース名) |
+   | `password` | `blog4-tidb` の `root-password` と同じ値 |
+
+3. AppRun に反映する:
+
+   ```bash
+   cd terraform
+   op run --env-file=.env -- terraform plan    # env 以外に差分が出ていないことを確認
+   op run --env-file=.env -- terraform apply
+   ```
+
+4. 動作確認: `/healthz`、トップページ、管理画面のログインと記事の保存
+5. 直前にもう一度 `db-count.sh both` を回し、切り替え後に記事数が減っていないか見る
+
+### 8. 切り戻し
+
+TiDB 側で問題が出たら、1Password の `blog4-app-db` を旧 MariaDB の値に戻して
+`terraform apply` する。DB のデータは手順2のダンプから戻せる:
+
+```bash
+op run --env-file=terraform/.env -- ./scripts/db-restore.sh --target mariadb /tmp/blog4-mariadb-<timestamp>.sql.gz
+```
+
+旧 EDB を廃止するまでは、この経路を残しておく。
+
+### 9. 後片付け
+
+- `/tmp` のダンプは**平文の記事データ**。作業が終わったら消す
+  (`shred -u /tmp/blog4-*.sql*`)。長期保管するなら `blog4-backup` バケットへ
+- 数日運用して問題なければ旧 EDB MariaDB を廃止する
+- 廃止後、この runbook の MariaDB 側の手順は不要になる
+
+## 補足
+
+- TiDB CR の `max_connections` は 50 (`terraform output tidb_max_connections`)。
+  ダンプ/リストア中にアプリが動いていても枯渇しない範囲だが、並列実行はしない
+- `db-dump.sh` は `--single-transaction --no-tablespaces --skip-add-locks --skip-disable-keys`
+  を付けている。EDB の制限された権限でも通り、`LOCK TABLES` / `DISABLE KEYS` が
+  TiDB へのリストアで問題にならないようにするため
+- ローカルの docker-compose の MariaDB を相手にスクリプトを試すときは
+  `DB_DOCKER_NETWORK=blog4_default MARIADB_TLS_CNF=ssl=0` を付ける

--- a/scripts/db-count.sh
+++ b/scripts/db-count.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# blog4 の DB に入っている件数 (記事数など) を表示する。
+#
+# 使い方:
+#   op run --env-file=terraform/.env -- ./scripts/db-count.sh            # TiDB (デフォルト)
+#   op run --env-file=terraform/.env -- ./scripts/db-count.sh mariadb    # 旧 EDB MariaDB
+#   op run --env-file=terraform/.env -- ./scripts/db-count.sh both       # 両方を並べて比較
+#
+# 移行後の件数一致チェックには both を使う。差があるテーブルには * が付く。
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/db-common.sh
+. scripts/lib/db-common.sh
+
+target="${1:-tidb}"
+case "$target" in
+tidb | mariadb | both) ;;
+*) die "usage: $0 [tidb|mariadb|both]" ;;
+esac
+
+# 指定 DB の "名前<TAB>件数" を outfile に書く。
+collect_counts() {
+	local t="$1" outfile="$2"
+
+	db_config "$t"
+	info "counting: $(db_describe)"
+
+	local tables
+	tables="$(db_query_tsv "SELECT table_name FROM information_schema.tables
+	                        WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
+	                        ORDER BY table_name")"
+
+	if [ -z "$tables" ]; then
+		info "テーブルが1つもない (移行前の TiDB ならこれが正常)"
+		: >"$outfile"
+		return
+	fi
+
+	local sql="" t_name
+	while IFS= read -r t_name; do
+		[ -n "$t_name" ] || continue
+		if [ -n "$sql" ]; then
+			sql+=" UNION ALL "
+		fi
+		sql+="SELECT '$t_name' AS n, COUNT(*) AS c FROM \`$t_name\`"
+		# entry は visibility の内訳も出す (公開記事が何件かは移行検証で見たい)。
+		if [ "$t_name" = "entry" ]; then
+			sql+=" UNION ALL SELECT CONCAT('entry:', visibility), COUNT(*) FROM \`entry\` GROUP BY visibility"
+		fi
+	done <<<"$tables"
+
+	db_query_tsv "$sql" >"$outfile"
+}
+
+# 表示順: テーブル名のアルファベット順。entry の直後に entry:public / entry:private。
+sort_keys() {
+	LC_ALL=C sort -u -t: -k1,1 -k2,2
+}
+
+# counts ファイル群に現れる行名を表示順に列挙する。
+list_keys() {
+	cut -f1 "$@" | sort_keys
+}
+
+# counts ファイルから行名に対応する件数を取る (無ければ空)。
+lookup_count() {
+	awk -F'\t' -v n="$2" '$1 == n { print $2 }' "$1"
+}
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/blog4-count.XXXXXX")"
+trap 'rm -rf "$tmpdir"; db_cleanup' EXIT
+
+case "$target" in
+tidb | mariadb)
+	collect_counts "$target" "$tmpdir/counts"
+	echo
+	printf '%-20s %12s\n' "table" "$target"
+	printf '%-20s %12s\n' "--------------------" "------------"
+	list_keys "$tmpdir/counts" | while IFS= read -r name; do
+		[ -n "$name" ] || continue
+		printf '%-20s %12s\n' "$name" "$(lookup_count "$tmpdir/counts" "$name")"
+	done
+	;;
+both)
+	collect_counts mariadb "$tmpdir/mariadb"
+	collect_counts tidb "$tmpdir/tidb"
+	echo
+	printf '%-20s %12s %12s   %s\n' "table" "mariadb" "tidb" "diff"
+	printf '%-20s %12s %12s   %s\n' "--------------------" "------------" "------------" "----"
+	# 両方に現れる行名を突き合わせる。片方にしかないものは - を表示し、差があれば * を付ける。
+	list_keys "$tmpdir/mariadb" "$tmpdir/tidb" | while IFS= read -r name; do
+		[ -n "$name" ] || continue
+		m_count="$(lookup_count "$tmpdir/mariadb" "$name")"
+		t_count="$(lookup_count "$tmpdir/tidb" "$name")"
+		mark=""
+		if [ "$m_count" != "$t_count" ]; then
+			mark="*"
+		fi
+		printf '%-20s %12s %12s   %s\n' "$name" "${m_count:--}" "${t_count:--}" "$mark"
+	done
+	;;
+esac

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# blog4 の DB を mysqldump して /tmp に置く。
+#
+# 使い方:
+#   op run --env-file=terraform/.env -- ./scripts/db-dump.sh both        # 両方バックアップ
+#   op run --env-file=terraform/.env -- ./scripts/db-dump.sh mariadb     # 旧 EDB だけ
+#   op run --env-file=terraform/.env -- ./scripts/db-dump.sh --data-only --exclude-sessions mariadb
+#
+# 移行用のデータ投入ファイルを作るときは --data-only --exclude-sessions を使う。
+# スキーマは本番 MariaDB のもの (FULLTEXT インデックスが残っている可能性がある) ではなく
+# db/init/01-schema.sql を正とするため、移行では CREATE TABLE をダンプに含めない。
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/db-common.sh
+. scripts/lib/db-common.sh
+
+usage() {
+	cat >&2 <<'EOF'
+usage: db-dump.sh [options] [tidb|mariadb|both]
+
+options:
+  --data-only          CREATE TABLE を含めない (移行のデータ投入用)
+  --schema-only        データを含めない
+  --exclude-sessions   admin_session テーブルを除外する (移行では引き継がない)
+  --out-dir DIR        出力先ディレクトリ (default: /tmp)
+  --gzip               gzip で圧縮する
+  -h, --help           このヘルプ
+EOF
+	exit 1
+}
+
+target=""
+data_only=0
+schema_only=0
+exclude_sessions=0
+out_dir="/tmp"
+use_gzip=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--data-only) data_only=1 ;;
+	--schema-only) schema_only=1 ;;
+	--exclude-sessions) exclude_sessions=1 ;;
+	--out-dir)
+		out_dir="${2:-}"
+		[ -n "$out_dir" ] || usage
+		shift
+		;;
+	--gzip) use_gzip=1 ;;
+	-h | --help) usage ;;
+	tidb | mariadb | both) target="$1" ;;
+	*) usage ;;
+	esac
+	shift
+done
+
+target="${target:-both}"
+if [ "$data_only" -eq 1 ] && [ "$schema_only" -eq 1 ]; then
+	die "--data-only と --schema-only は同時に指定できない"
+fi
+[ -d "$out_dir" ] || die "出力先ディレクトリがない: $out_dir"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+
+trap db_cleanup EXIT
+
+dump_one() {
+	local t="$1"
+
+	db_config "$t"
+
+	local args=(
+		--single-transaction # LOCK TABLES 権限なしでも一貫性のあるダンプを取る
+		--no-tablespaces     # PROCESS 権限がなくても失敗しないようにする
+		--skip-triggers      # トリガーは使っていない
+		--skip-add-locks     # LOCK TABLES 文は TiDB へのリストアで邪魔になる
+		--skip-disable-keys  # ALTER TABLE ... DISABLE KEYS も同様
+		--complete-insert    # 列名付き INSERT にしてカラム順の差異に強くする
+		--hex-blob
+	)
+
+	# mysql 8 系クライアント固有のオプション (mariadb クライアントには無い)。
+	if [ "$t" = "tidb" ]; then
+		args+=(--set-gtid-purged=OFF --column-statistics=0)
+	fi
+
+	local suffix=""
+	if [ "$data_only" -eq 1 ]; then
+		args+=(--no-create-info)
+		suffix="-data"
+	elif [ "$schema_only" -eq 1 ]; then
+		args+=(--no-data)
+		suffix="-schema"
+	fi
+
+	if [ "$exclude_sessions" -eq 1 ]; then
+		args+=("--ignore-table=${DB_NAME}.admin_session")
+	fi
+
+	local out="$out_dir/blog4-${t}-${timestamp}${suffix}.sql"
+	if [ "$use_gzip" -eq 1 ]; then
+		out="${out}.gz"
+	fi
+
+	info "dumping: $(db_describe) -> $out"
+
+	# ダンプ途中で失敗したファイルを残さない (中途半端なファイルをリストアしないため)。
+	local tmp_out="${out}.partial"
+	if [ "$use_gzip" -eq 1 ]; then
+		db_client mysqldump "${args[@]}" "$DB_NAME" | gzip >"$tmp_out"
+	else
+		db_client mysqldump "${args[@]}" "$DB_NAME" >"$tmp_out"
+	fi
+	mv "$tmp_out" "$out"
+	chmod 600 "$out"
+
+	info "done: $out ($(du -h "$out" | cut -f1))"
+	echo "$out"
+}
+
+case "$target" in
+both)
+	dump_one mariadb
+	dump_one tidb
+	;;
+*)
+	dump_one "$target"
+	;;
+esac

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SQL ファイルを DB に流し込む。移行のリストア (MariaDB のダンプ → TiDB) 用。
+#
+# 使い方:
+#   # スキーマを作る (db/init/01-schema.sql が TiDB 互換スキーマの正)
+#   op run --env-file=terraform/.env -- ./scripts/db-restore.sh db/init/01-schema.sql
+#
+#   # MariaDB から取ったデータダンプを流し込む
+#   op run --env-file=terraform/.env -- ./scripts/db-restore.sh /tmp/blog4-mariadb-20260723-101500-data.sql
+#
+# デフォルトの流し込み先は TiDB。MariaDB へ戻す (切り戻し) 場合のみ --target mariadb。
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/db-common.sh
+. scripts/lib/db-common.sh
+
+usage() {
+	cat >&2 <<'EOF'
+usage: db-restore.sh [options] <file.sql|file.sql.gz>
+
+options:
+  --target tidb|mariadb   流し込み先 (default: tidb)
+  --yes                   確認プロンプトを出さない
+  -h, --help              このヘルプ
+EOF
+	exit 1
+}
+
+target="tidb"
+assume_yes=0
+file=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--target)
+		target="${2:-}"
+		[ -n "$target" ] || usage
+		shift
+		;;
+	--yes) assume_yes=1 ;;
+	-h | --help) usage ;;
+	-*) usage ;;
+	*) file="$1" ;;
+	esac
+	shift
+done
+
+[ -n "$file" ] || usage
+[ -f "$file" ] || die "ファイルがない: $file"
+
+trap db_cleanup EXIT
+
+db_config "$target"
+
+# 流し込む前に現状を見せる。空でない DB に上書きするときに気づけるようにする。
+existing="$(db_query_tsv "SELECT COUNT(*) FROM information_schema.tables
+                          WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'")"
+
+echo "restore 先 : $(db_describe)" >&2
+echo "既存テーブル: ${existing} 個" >&2
+echo "流し込む file: $file" >&2
+
+if [ "$assume_yes" -ne 1 ]; then
+	printf 'この内容で実行する? [y/N] ' >&2
+	read -r answer
+	case "$answer" in
+	y | Y | yes | YES) ;;
+	*) die "中止した" ;;
+	esac
+fi
+
+info "restoring..."
+case "$file" in
+*.gz) gzip -dc "$file" | db_client mysql --database="$DB_NAME" ;;
+*) db_client mysql --database="$DB_NAME" <"$file" ;;
+esac
+
+info "done. ./scripts/db-count.sh $target で件数を確認する"

--- a/scripts/lib/db-common.sh
+++ b/scripts/lib/db-common.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# blog4 の DB (TiDB CR / 旧 EDB MariaDB) に接続するための共通処理。
+#
+# 単体では実行しない。db-count.sh / db-dump.sh / db-restore.sh から source する。
+#
+# 認証情報の正本は 1Password (blog4 vault) なので、呼び出し側は op run 経由で実行する:
+#   op run --env-file=terraform/.env -- ./scripts/db-count.sh
+#
+# ローカルに mysql クライアントを入れずに済むよう、クライアントは docker で動かす。
+# TiDB は MySQL 8 互換なので mysql:8, 旧 EDB は mariadb: のクライアントを使う。
+
+TIDB_CLIENT_IMAGE="${TIDB_CLIENT_IMAGE:-mysql:8.4}"
+MARIADB_CLIENT_IMAGE="${MARIADB_CLIENT_IMAGE:-mariadb:10.11.18}"
+
+DB_COMMON_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+die() {
+	echo "error: $*" >&2
+	exit 1
+}
+
+info() {
+	echo "==> $*" >&2
+}
+
+# terraform output から TiDB のホスト名を取る (TIDB_HOST 未指定時のフォールバック)。
+tidb_hostname_from_terraform() {
+	local host
+	if ! host="$(cd "$DB_COMMON_REPO_ROOT/terraform" && terraform output -raw tidb_hostname 2>/dev/null)"; then
+		die "TiDB のホスト名を解決できない。TIDB_HOST を明示するか、terraform/ で init 済みの状態で実行する"
+	fi
+	[ -n "$host" ] || die "terraform output tidb_hostname が空"
+	echo "$host"
+}
+
+# 接続情報を DB_* に展開する。
+#   db_config tidb|mariadb
+db_config() {
+	local target="$1"
+
+	case "$target" in
+	tidb)
+		# TiDB CR (さくらのオンデマンドデータベース)。ポートは 4000 固定、TLS 必須。
+		# ユーザ名はデータベース名と同じ (EDB/オンデマンドDB の仕様)。違う場合は TIDB_USER で上書き。
+		DB_NAME="${TIDB_DATABASE:-${TF_VAR_tidb_database_name:-blog4}}"
+		DB_HOST="${TIDB_HOST:-$(tidb_hostname_from_terraform)}"
+		DB_PORT="${TIDB_PORT:-4000}"
+		DB_USER="${TIDB_USER:-$DB_NAME}"
+		DB_PASSWORD="${TIDB_PASSWORD:-${TF_VAR_tidb_password:-}}"
+		DB_IMAGE="$TIDB_CLIENT_IMAGE"
+		DB_TLS_CNF="${TIDB_TLS_CNF:-ssl-mode=REQUIRED}"
+		;;
+	mariadb)
+		# 旧 EDB MariaDB = 現在アプリが繋いでいる DB。値は 1Password の blog4-app-db。
+		DB_HOST="${TF_VAR_database_host:-}"
+		DB_PORT="${TF_VAR_database_port:-3306}"
+		DB_NAME="${TF_VAR_database_name:-}"
+		DB_USER="${TF_VAR_database_user:-}"
+		DB_PASSWORD="${TF_VAR_database_password:-}"
+		DB_IMAGE="$MARIADB_CLIENT_IMAGE"
+		# ローカルの docker-compose MariaDB を相手に検証するときは MARIADB_TLS_CNF="ssl=0"。
+		DB_TLS_CNF="${MARIADB_TLS_CNF:-ssl=1}"
+		[ -n "$DB_HOST" ] || die "TF_VAR_database_host が空。op run --env-file=terraform/.env 経由で実行しているか確認する"
+		[ -n "$DB_NAME" ] || die "TF_VAR_database_name が空"
+		[ -n "$DB_USER" ] || die "TF_VAR_database_user が空"
+		;;
+	*)
+		die "unknown target: $target (tidb|mariadb)"
+		;;
+	esac
+
+	[ -n "$DB_PASSWORD" ] || die "$target のパスワードが空。op run --env-file=terraform/.env 経由で実行しているか確認する"
+
+	DB_TARGET="$target"
+	db_write_defaults_file
+}
+
+# my.cnf の値をエスケープする (バックスラッシュとダブルクォート)。
+cnf_escape() {
+	printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# パスワードを引数に置くと ps や docker inspect から見えるので、
+# 600 の一時ファイルに書いてコンテナへ read-only マウントする。
+# 後始末は呼び出し側が `trap db_cleanup EXIT` で行う。
+db_write_defaults_file() {
+	# 同一プロセスで複数の接続先を切り替えるときに前の分を残さない。
+	db_cleanup
+
+	DB_DEFAULTS_FILE="$(mktemp "${TMPDIR:-/tmp}/blog4-client.cnf.XXXXXX")"
+	chmod 600 "$DB_DEFAULTS_FILE"
+
+	cat >"$DB_DEFAULTS_FILE" <<EOF
+[client]
+host="$(cnf_escape "$DB_HOST")"
+port=$DB_PORT
+user="$(cnf_escape "$DB_USER")"
+password="$(cnf_escape "$DB_PASSWORD")"
+$DB_TLS_CNF
+default-character-set=utf8mb4
+EOF
+}
+
+# 認証情報を書いた一時ファイルを消す。呼び出し側は trap db_cleanup EXIT すること。
+db_cleanup() {
+	if [ -n "${DB_DEFAULTS_FILE:-}" ]; then
+		rm -f "$DB_DEFAULTS_FILE"
+		DB_DEFAULTS_FILE=""
+	fi
+}
+
+# docker 経由で mysql / mysqldump を実行する。
+#   db_client mysql [args...]
+db_client() {
+	local prog="$1"
+	shift
+
+	local docker_args=(--rm -i -v "$DB_DEFAULTS_FILE:/etc/blog4-client.cnf:ro")
+	# ローカルの docker-compose の DB を相手にするとき用 (例: DB_DOCKER_NETWORK=blog4_default)。
+	if [ -n "${DB_DOCKER_NETWORK:-}" ]; then
+		docker_args+=(--network "$DB_DOCKER_NETWORK")
+	fi
+
+	docker run "${docker_args[@]}" "$DB_IMAGE" \
+		"$prog" --defaults-extra-file=/etc/blog4-client.cnf "$@"
+}
+
+# SQL を投げてタブ区切り (ヘッダなし) で受け取る。
+db_query_tsv() {
+	db_client mysql --batch --skip-column-names --database="$DB_NAME" -e "$1"
+}
+
+# 接続先の表示用文字列。
+db_describe() {
+	echo "$DB_TARGET ($DB_USER@$DB_HOST:$DB_PORT/$DB_NAME)"
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,6 +9,8 @@
 - パスワード等の機微情報: `password_wo` (write-only argument, Terraform 1.11+) と `TF_VAR_*` 環境変数で渡す。state に平文では入らない
 - tfstate: さくらのオブジェクトストレージ (S3 互換) backend。`backend.tf` 参照。state ロックは S3 ネイティブの `use_lockfile`
 - 移行方針の全体像: [../architecture/migration-plan.md](../architecture/migration-plan.md)
+- DB 移行の実作業手順: [../architecture/migration-runbook.md](../architecture/migration-runbook.md)
+  (件数確認・ダンプ・リストアは `scripts/db-count.sh` / `db-dump.sh` / `db-restore.sh`)
 
 ## このディレクトリで定義しているリソース
 


### PR DESCRIPTION
EDB MariaDB → TiDB CR の移行作業に使うスクリプトと手順書を追加する。

## スクリプト

| ファイル | 役割 |
|---|---|
| `scripts/db-count.sh [tidb\|mariadb\|both]` | テーブル別件数。`entry` は public/private の内訳も出す。`both` は横並びで差分に `*` |
| `scripts/db-dump.sh [opts] [tidb\|mariadb\|both]` | mysqldump して `/tmp` へ。`--data-only` `--exclude-sessions` `--gzip` `--out-dir` |
| `scripts/db-restore.sh [--target] <file>` | SQL を流し込む (確認プロンプト付き、`.gz` 対応) |
| `scripts/lib/db-common.sh` | 接続情報の解決とクライアント実行の共通処理 |

- mysql クライアントはローカルに入れず docker で動かす (TiDB へは `mysql:8.4`、旧 EDB へは `mariadb:10.11.18`)
- パスワードは 600 の一時 my.cnf 経由。`ps` や `docker inspect` には出ない
- 接続情報は `op run --env-file=terraform/.env` 前提。TiDB のホストは `terraform output tidb_hostname`、MariaDB は `TF_VAR_database_*` (1Password の `blog4-app-db`)

## 手順書

`architecture/migration-runbook.md` に「両方カウント → 両方バックアップ → MariaDB から TiDB へ移す → 両方カウント」の手順をまとめた。切り戻しと後片付けも記載。

あわせて、移行前に潰す必要があるアプリ側の課題も書いてある (このPRでは直していない):

1. アプリが TLS で DB に繋げない (`cmd/blog4/main.go:35` の `mysql.Config` に `TLSConfig` がない)。TiDB CR は TLS 必須
2. `terraform/apprun.tf:17` は `DATABASE_NAME` を送るが、アプリが読むのは `DATABASE_DB` (`internal/config.go:16`、デフォルト `blog3`)
3. `internal/backup.go:43` の日次バックアップが `mariadb-dump` 依存

## 動作確認

ローカルに MariaDB 10.11.18 と MySQL 8.4 のコンテナを立てて、`db/init/` のスキーマ + ダミーデータで全経路を実行した (count both → dump both → schema restore → data-only dump → restore → count both)。移行後の件数が一致することを確認済み。

```
table                     mariadb         tidb   diff
-------------------- ------------ ------------   ----
admin_session                   0            0
amazon_cache                    2            2
entry                           8            8
entry:private                   1            1
entry:public                    7            7
entry_image                     7            7
entry_link                     14           14
```

TiDB のユーザ名は「データベース名と同じ (`blog5`)」と仮定している。未確認なので、疎通確認で認証エラーが出たら `TIDB_USER=` で上書きし、判明した値を runbook に反映する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)