### PR TITLE
fix(terraform): AppRun の drift を解消し component name を ignore_changes に入れる

### DIFF
--- a/terraform/apprun.tf
+++ b/terraform/apprun.tf
@@ -6,6 +6,11 @@
 #
 # image は CI (.github/actions/deploy-apprun/deploy.sh) が毎デプロイで PATCH
 # するため lifecycle.ignore_changes で管理外にする。traffics も CI 側。
+#
+# component name はイメージタグ入りの名前で、CI 側では変えていないが
+# 過去のデプロイ経緯で実態とずれうる。name は forces replacement 属性なので、
+# ずれたまま apply するとアプリごと作り直され public_url が変わる
+# (= WebAccel の origin が切れて blog.64p.org が落ちる)。ここも管理外にする。
 locals {
   # AppRun に流し込む環境変数。実値は 1Password 由来 (TF_VAR_* / op run)。
   apprun_env = {
@@ -34,16 +39,18 @@ resource "sakura_apprun_shared" "blog4" {
 
   components = [
     {
-      # CI は image しか PATCH しないため component name は安定 (タグ込みだが固定)。
-      name       = "blog4:75e6b60"
+      # name / image は ignore_changes 対象 (実値は CI とデプロイ履歴が決める)。
+      # ゼロから作り直すときの初期値として、現行の実態に合わせておく。
+      name       = "blog4:3bfb434"
       max_cpu    = "0.5"
       max_memory = "1Gi"
 
       deploy_source = {
         container_registry = {
-          image    = "tokuhirom-private.sakuracr.jp/blog4:75e6b60"
-          server   = "tokuhirom-private.sakuracr.jp"
-          username = "pull"
+          # ghcr.io の public パッケージなので pull に認証は要らない。
+          # server / username は optional かつ computed なので、指定しない
+          # (CI も PATCH で username/password を削除している)。
+          image = "ghcr.io/tokuhirom/blog4:3bfb434"
         }
       }
 
@@ -53,6 +60,7 @@ resource "sakura_apprun_shared" "blog4" {
 
   lifecycle {
     ignore_changes = [
+      components[0].name,
       components[0].deploy_source.container_registry.image,
       traffics,
     ]


### PR DESCRIPTION
## 何が起きていたか

DB 移行のカットオーバー手順 (`terraform apply` で AppRun の env を TiDB 向けに差し替える) の前に `terraform plan` を打ったところ、**`sakura_apprun_shared.blog4` が replace (destroy & create) 対象**になっていた。

```
  # sakura_apprun_shared.blog4 must be replaced
-/+ resource "sakura_apprun_shared" "blog4" {
      ~ name = "blog4:3bfb434" -> "blog4:75e6b60" # forces replacement
      ~ image = "ghcr.io/tokuhirom/blog4:3bfb434" -> "tokuhirom-private.sakuracr.jp/blog4:75e6b60"
```

`name` は forces replacement 属性なので、このまま apply するとアプリごと作り直しになり **`public_url` が変わって WebAccel の origin が切れる**（= blog.64p.org が落ちる）。

## 直したこと

- **`components[0].name` を `ignore_changes` に追加** — タグ入りの名前なのでデプロイ経緯でまたずれうる。値も現行の実態 (`blog4:3bfb434`) に合わせた
- **image を ghcr.io に更新** — #964 で sakuracr.jp から移行済みだったのに tf が追随していなかった
- **`server` / `username` の指定を削除** — ghcr の public パッケージなので pull に認証は不要で、CI も PATCH で `username`/`password` を消している。どちらも optional + computed なので指定しなければ差分にならない

## 確認

```
$ op run --env-file=.env -- terraform plan -target=sakura_apprun_shared.blog4
No changes. Your infrastructure matches the configuration.
```

env も差分なし = 1Password の値と本番の値が一致していることも確認できた。

## 残っている plan の差分

`sakura_webaccel.blog4` が「設定にない」として destroy 対象のまま。これは import 済みなのに `.tf` が未マージの #878 にあるため。**#878 をマージしないと `terraform apply` は打てない。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)