### PR TITLE
fix(deploy): container_registry の認証フィールドを送らない

### DIFF
--- a/.github/actions/deploy-apprun/deploy.sh
+++ b/.github/actions/deploy-apprun/deploy.sh
@@ -20,12 +20,16 @@ curl -f --no-progress-meter -u "$access_token_id:$access_token_secret" -o 'app.j
   "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/$apprun_app_id"
 
 # app.json から deploy.json を生成
-# - container_registry.server を ghcr.io に設定
-# - public パッケージなので username / password は不要(削除する)
+# - container_registry の認証系フィールド (server / username / password) を削除する。
+#   ghcr.io の public パッケージなので pull に認証は要らない。server だけを送ると
+#   AppRun API が Username と Password も必須と判定して 400 を返す:
+#     "Authentication to Container Registry requires Server, Username, and Password."
+#   どこから引くかは image のフルパス (ghcr.io/...) で決まるので server は不要。
 # - all_traffic_available を true に設定
 jq --arg image "$image" '
-  .components[0].deploy_source.container_registry.server = "ghcr.io"
-  | del(.components[0].deploy_source.container_registry.username, .components[0].deploy_source.container_registry.password)
+  del(.components[0].deploy_source.container_registry.server,
+      .components[0].deploy_source.container_registry.username,
+      .components[0].deploy_source.container_registry.password)
   | .all_traffic_available = true
   | .components[0].deploy_source.container_registry.image = "\($image)"
 ' app.json > deploy.json


### PR DESCRIPTION
## 何が起きていたか

**2026-07-21 以降、本番へのデプロイがずっと失敗していた** (#961 / #962 / #963 / #964 / #965 / #966 のマージ時の "Publish Docker Image" がすべて failure)。イメージのビルドと ghcr への push は成功しており、失敗しているのは AppRun への Deploy ステップのみ。

```
+ curl --fail-with-body ... -X PATCH -d @deploy.json https://secure.sakura.ad.jp/.../applications/...
curl: (22) The requested URL returned error: 400
{"error":{"code":400,"message":"Validation Error","errors":[{"domain":"global",
 "reason":"violates application restriction",
 "message":"Authentication to Container Registry requires Server, Username, and Password."}]}}
```

`deploy.sh` が `server` だけを `"ghcr.io"` にセットして `username` / `password` は削除していたため。AppRun API は認証情報を **3 点セットで** 要求するので、一部だけ送ると弾かれる。

## 直したこと

`server` も含めて認証系フィールドをすべて削除する。ghcr.io の public パッケージなので pull に認証は不要で、どのレジストリから引くかは image のフルパス (`ghcr.io/...`) で決まる。本番の AppRun も実際に `server` / `username` が空の状態で動いている。

## 確認

実際の `app.json` (本番の GET 結果) に対して jq を流して検証:

```json
{
  "all_traffic_available": true,
  "component_name": "blog4:3bfb434",
  "registry": { "image": "ghcr.io/tokuhirom/blog4:2e2383d" },
  "env_count": 13
}
```

認証系フィールドが消え、env 13 個はそのまま維持される。

## なぜ今これが問題か

DB 移行のカットオーバー直前にこれが見つかった。**#966 の TLS 対応が本番に入っていない**状態で DB を TiDB に切り替えると、アプリが TiDB に接続できず落ちる。この PR をマージしてデプロイを通してからでないとカットオーバーできない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)